### PR TITLE
feat: 공통 정상 및 비정상 응답 추가 

### DIFF
--- a/src/main/java/com/nameplz/baedal/global/common/exception/GlobalException.java
+++ b/src/main/java/com/nameplz/baedal/global/common/exception/GlobalException.java
@@ -1,0 +1,18 @@
+package com.nameplz.baedal.global.common.exception;
+
+import com.nameplz.baedal.global.common.response.ResultCase;
+import lombok.Getter;
+
+/**
+ * 전역 예외 처리를 위한 커스텀 예외 클래스 - ResultCase 받아서 처리
+ */
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final ResultCase resultCase;
+
+    public GlobalException(ResultCase resultCase) {
+        super(resultCase.getMessage());
+        this.resultCase = resultCase;
+    }
+}

--- a/src/main/java/com/nameplz/baedal/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nameplz/baedal/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.nameplz.baedal.global.common.exception;
+
+import com.nameplz.baedal.global.common.response.CommonResponse;
+import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import com.nameplz.baedal.global.common.response.ResultCase;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+/**
+ * 전역 예외 처리 핸들러
+ */
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private final InvalidInputMapper mapper;
+    private final HttpServletResponse response; // HttpStatus 설정을 위한 response 객체
+
+    /**
+     * Business 오류 발생에 대한 핸들러
+     */
+    @ExceptionHandler(GlobalException.class)
+    public CommonResponse<EmptyResponseDto> handleGlobalException(GlobalException e) {
+        response.setStatus(e.getResultCase().getHttpStatus().value()); // HttpStatus 설정
+
+        return CommonResponse.error(e.getResultCase()); // 공통 응답 양식 반환
+    }
+
+    /**
+     * Validation 라이브러리로 RequestBody 입력 파라미터 검증 오류 발생에 대한 핸들러
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public CommonResponse<List<InvalidInputResponseDto>> handlerValidationException(MethodArgumentNotValidException e) {
+        // 잘못된 입력 에러들을 DTO 변환
+        List<InvalidInputResponseDto> invalidInputResList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(mapper::toInvalidInputResponseDto) // defaultMessage 필드명을 message 변경
+                .toList();
+
+        response.setStatus(ResultCase.INVALID_INPUT.getHttpStatus().value()); // HttpStatus 설정
+
+        return CommonResponse.error(ResultCase.INVALID_INPUT, invalidInputResList); // 공통 응답 양식 반환
+    }
+}

--- a/src/main/java/com/nameplz/baedal/global/common/exception/InvalidInputMapper.java
+++ b/src/main/java/com/nameplz/baedal/global/common/exception/InvalidInputMapper.java
@@ -1,0 +1,14 @@
+package com.nameplz.baedal.global.common.exception;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.springframework.validation.FieldError;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING) // 빈으로 주입받을 수 있음
+public interface InvalidInputMapper {
+
+    // FieldError 의 defaultMessage -> message 이름 변경
+    @Mapping(source = "defaultMessage", target = "message")
+    InvalidInputResponseDto toInvalidInputResponseDto(FieldError fieldError);
+}

--- a/src/main/java/com/nameplz/baedal/global/common/exception/InvalidInputResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/global/common/exception/InvalidInputResponseDto.java
@@ -1,0 +1,4 @@
+package com.nameplz.baedal.global.common.exception;
+
+public record InvalidInputResponseDto(String field, String message) {
+}

--- a/src/main/java/com/nameplz/baedal/global/common/response/CommonResponse.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/CommonResponse.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 import java.io.Serializable;
 
@@ -14,7 +13,6 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class CommonResponse<T> implements Serializable {
 
-    private HttpStatus status; // 응답 상태코드
     private Integer code; // 커스텀 응답 코드
     private String message; // 응답에 대한 설명
     private T data; // 응답에 필요한 데이터
@@ -24,7 +22,6 @@ public class CommonResponse<T> implements Serializable {
      */
     public static CommonResponse<EmptyResponseDto> success() {
         return CommonResponse.<EmptyResponseDto>builder()
-                .status(ResultCase.SUCCESS.getHttpStatus())
                 .code(ResultCase.SUCCESS.getCode())
                 .message(ResultCase.SUCCESS.getMessage())
                 .data(new EmptyResponseDto())
@@ -36,7 +33,6 @@ public class CommonResponse<T> implements Serializable {
      */
     public static <T> CommonResponse<T> success(T data) {
         return CommonResponse.<T>builder()
-                .status(ResultCase.SUCCESS.getHttpStatus())
                 .code(ResultCase.SUCCESS.getCode())
                 .message(ResultCase.SUCCESS.getMessage())
                 .data(data)
@@ -49,7 +45,6 @@ public class CommonResponse<T> implements Serializable {
     public static CommonResponse<EmptyResponseDto> error(ResultCase resultCase) {
 
         return CommonResponse.<EmptyResponseDto>builder()
-                .status(resultCase.getHttpStatus())
                 .code(resultCase.getCode())
                 .message(resultCase.getMessage())
                 .data(new EmptyResponseDto())
@@ -61,7 +56,6 @@ public class CommonResponse<T> implements Serializable {
      */
     public static <T> CommonResponse<T> error(ResultCase resultCase, T data) {
         return CommonResponse.<T>builder()
-                .status(resultCase.getHttpStatus())
                 .code(resultCase.getCode())
                 .message(resultCase.getMessage())
                 .data(data)

--- a/src/main/java/com/nameplz/baedal/global/common/response/CommonResponse.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/CommonResponse.java
@@ -1,0 +1,70 @@
+package com.nameplz.baedal.global.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serializable;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse<T> implements Serializable {
+
+    private HttpStatus status; // 응답 상태코드
+    private Integer code; // 커스텀 응답 코드
+    private String message; // 응답에 대한 설명
+    private T data; // 응답에 필요한 데이터
+
+    /**
+     * data 필드에 값을 넣을 때 사용하는 메서드 - data 필드가 필요 없는 경우
+     */
+    public static CommonResponse<EmptyResponseDto> success() {
+        return CommonResponse.<EmptyResponseDto>builder()
+                .status(ResultCase.SUCCESS.getHttpStatus())
+                .code(ResultCase.SUCCESS.getCode())
+                .message(ResultCase.SUCCESS.getMessage())
+                .data(new EmptyResponseDto())
+                .build();
+    }
+
+    /**
+     * data 필드에 값을 넣을 때 사용하는 메서드 - data 필드가 필요한 경우
+     */
+    public static <T> CommonResponse<T> success(T data) {
+        return CommonResponse.<T>builder()
+                .status(ResultCase.SUCCESS.getHttpStatus())
+                .code(ResultCase.SUCCESS.getCode())
+                .message(ResultCase.SUCCESS.getMessage())
+                .data(data)
+                .build();
+    }
+
+    /**
+     * 에러 발생 시 특정 에러에 맞는 응답하는 메서드 - data 필드가 필요 없는 경우
+     */
+    public static CommonResponse<EmptyResponseDto> error(ResultCase resultCase) {
+
+        return CommonResponse.<EmptyResponseDto>builder()
+                .status(resultCase.getHttpStatus())
+                .code(resultCase.getCode())
+                .message(resultCase.getMessage())
+                .data(new EmptyResponseDto())
+                .build();
+    }
+
+    /**
+     * 에러 발생 시 특정 에러에 맞는 응답하는 메서드 - data 필드가 필요한 경우
+     */
+    public static <T> CommonResponse<T> error(ResultCase resultCase, T data) {
+        return CommonResponse.<T>builder()
+                .status(resultCase.getHttpStatus())
+                .code(resultCase.getCode())
+                .message(resultCase.getMessage())
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/nameplz/baedal/global/common/response/EmptyResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/EmptyResponseDto.java
@@ -1,0 +1,10 @@
+package com.nameplz.baedal.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * data 필드가 필요 없는 경우 null 대신 비어있는 객체를 응답하기 위한 DTO
+ */
+@JsonIgnoreProperties // 아무 필드가 없을 시 직렬화를 위한 어노테이션
+public record EmptyResponseDto() {
+}

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -24,7 +24,7 @@ public enum ResultCase {
 
     // 존재하지 않는 사용자 404,
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2000, "유저를 찾을 수 없습니다."),
-    // 로그인 필요 403
+    // 로그인 필요 401
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 2001, "로그인이 필요합니다.");
 
     private final HttpStatus httpStatus; // 응답 상태 코드

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -1,0 +1,33 @@
+package com.nameplz.baedal.global.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResultCase {
+
+    // 성공 0번대 - 모든 성공 응답을 200으로 통일
+    SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다"),
+
+    // 글로벌 1000번대
+
+    // 권한 없음 403
+    NOT_AUTHORIZED(HttpStatus.FORBIDDEN, 1000, "해당 요청에 대한 권한이 없습니다."),
+    // 잘못된 형식의 입력 400
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, 1001, "유효하지 않은 입력값입니다."),
+    // 시스템 에러 500
+    SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1002, "알 수 없는 에러가 발생했습니다."),
+
+    // 유저 2000번대
+
+    // 존재하지 않는 사용자 404,
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2000, "유저를 찾을 수 없습니다."),
+    // 로그인 필요 403
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 2001, "로그인이 필요합니다.");
+
+    private final HttpStatus httpStatus; // 응답 상태 코드
+    private final Integer code; // 응답 코드. 도메인에 따라 1000번대로 나뉨
+    private final String message; // 응답에 대한 설명
+}


### PR DESCRIPTION
## 개요
- 공통 정상 응답과 예외 응답 객체를 만들었습니다. 

## 작업사항
- 모든 응답 케이스를 담는 ResultCase Enum 추가
- 공통 응답을 위한 객체 추가 
- 입력 예외 응답 DTO 추가 
- 전역 예외 추가 
- 전역 예외 핸들러 추가 

## 관련 이슈
- 

## 추가 설명 
- 3번째 커밋은 제가 실수로 설명을 동일하게 커밋해버렸는데요, 공통 응답을 위한 객체를 추가했습니다.. 
- 이 PR은 이러면 어떨까 하고 제안을 위해 작성해보았습니다. 기존에 쓰던 양식 중 더 좋은 코드가 있다면 리뷰로 의논해보아요!!!

### 사용 예시 
```java
@RestController
public class TestController {

    @GetMapping("/success")
    public CommonResponse<EmptyResponseDto> success() {
        return CommonResponse.success();
    }

    @GetMapping("/fail")
    public CommonResponse<EmptyResponseDto> fail() {
        throw new GlobalException(ResultCase.LOGIN_REQUIRED);
    }
}
```
예시를 위한 컨트롤러 입니다.
    

```java
@Getter
@RequiredArgsConstructor
public enum ResultCase {

    // 성공 0번대 - 모든 성공 응답을 200으로 통일
    SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다"),

    // ...

    // 로그인 필요 403
    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 2001, "로그인이 필요합니다.");

    private final HttpStatus httpStatus; // 응답 상태 코드
    private final Integer code; // 응답 코드. 도메인에 따라 1000번대로 나뉨
    private final String message; // 응답에 대한 설명
}
```
예시에 쓰인 ResultCase 입니다.
    

```json
{
  "code": 0,
  "message": "정상 처리 되었습니다",
  "data": {}
}
```
정상 응답은 위와 같습니다.
    

```json
{
  "code": 2001,
  "message": "로그인이 필요합니다.",
  "data": {}
}
```
비정상 응답은 위와 같습니다. 
     