### PR TITLE
fix: Review 엔티티에 Store 연관관계 추가

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
@@ -1,6 +1,7 @@
 package com.nameplz.baedal.domain.review.domain;
 
 import com.nameplz.baedal.domain.model.BaseEntity;
+import com.nameplz.baedal.domain.store.domain.Store;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,6 +27,10 @@ public class Review extends BaseEntity {
 
     @Column(name = "is_reported")
     private boolean isReported;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
 
     public static Review create(String content, Integer rating) {
 

--- a/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
@@ -32,13 +32,14 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "store_id")
     private Store store;
 
-    public static Review create(String content, Integer rating) {
+    public static Review create(String content, Integer rating, Store store) {
 
         Review review = new Review();
 
         review.content = content;
         review.rating = rating;
         review.isReported = false;
+        review.store = store;
 
         return review;
     }


### PR DESCRIPTION
## 개요
- Review 엔티티에 Store 연관관계를 추가했습니다. 

## 작업사항
- `@ManyToOne` 관계로 Store를 추가 

## 관련 이슈
- 

## 추가 설명 
>```Caused by: org.hibernate.AnnotationException: Collection 'com.nameplz.baedal.domain.store.domain.Store.reviewList' is 'mappedBy' a property named 'store' which does not exist in the target entity 'com.nameplz.baedal.domain.review.domain.Review'```


위와 같은 에러로 스프링이 실행되지 않아서 추가를 해주었습니다. 