### PR TITLE
feat: 주문 도메인 보강

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/model/Address.java
+++ b/src/main/java/com/nameplz/baedal/domain/model/Address.java
@@ -1,0 +1,22 @@
+package com.nameplz.baedal.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class Address {
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    @Column(name = "detail_address")
+    private String detailAddress;
+
+    @Column(name = "zipcode", length = 100)
+    private String zipcode;
+}

--- a/src/main/java/com/nameplz/baedal/domain/model/Money.java
+++ b/src/main/java/com/nameplz/baedal/domain/model/Money.java
@@ -1,0 +1,31 @@
+package com.nameplz.baedal.domain.model;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class Money {
+
+    private Integer amount;
+
+    public Money add(Money money) {
+        return new Money(this.amount + money.amount);
+    }
+
+    public Money subtract(Money money) {
+        return new Money(this.amount - money.amount);
+    }
+
+    public Money multiply(int multiplier) {
+        return new Money(this.amount * multiplier);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(amount);
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -18,8 +18,8 @@ public class Order extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(name = "order_status")
-    @Embedded
+    @Column(name = "order_status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
     @Column(name = "comment")

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -2,6 +2,7 @@ package com.nameplz.baedal.domain.order.domain;
 
 import com.nameplz.baedal.domain.model.Address;
 import com.nameplz.baedal.domain.model.BaseEntity;
+import com.nameplz.baedal.domain.store.domain.Store;
 import com.nameplz.baedal.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -37,11 +38,15 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
     @BatchSize(size = 500)
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderLine> orderLines = new ArrayList<>();
 
-    public static Order create(OrderStatus orderStatus, String comment, Address address, User user) {
+    public static Order create(OrderStatus orderStatus, String comment, Address address, User user, Store store) {
 
         Order order = new Order();
 
@@ -49,6 +54,7 @@ public class Order extends BaseEntity {
         order.comment = comment;
         order.address = address;
         order.user = user;
+        order.store = store;
 
         return order;
     }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -1,5 +1,6 @@
 package com.nameplz.baedal.domain.order.domain;
 
+import com.nameplz.baedal.domain.model.Address;
 import com.nameplz.baedal.domain.model.BaseEntity;
 import com.nameplz.baedal.domain.user.domain.User;
 import jakarta.persistence.*;
@@ -29,6 +30,9 @@ public class Order extends BaseEntity {
     @Column(name = "comment")
     private String comment;
 
+    @Embedded
+    private Address address;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -37,12 +41,13 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderLine> orderLines = new ArrayList<>();
 
-    public static Order create(OrderStatus orderStatus, String comment, User user) {
+    public static Order create(OrderStatus orderStatus, String comment, Address address, User user) {
 
         Order order = new Order();
 
         order.orderStatus = orderStatus;
         order.comment = comment;
+        order.address = address;
         order.user = user;
 
         return order;

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -28,6 +28,10 @@ public class Order extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
+    @Column(name = "order_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OrderType orderType;
+
     @Column(name = "comment")
     private String comment;
 
@@ -46,11 +50,12 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderLine> orderLines = new ArrayList<>();
 
-    public static Order create(OrderStatus orderStatus, String comment, Address address, User user, Store store) {
+    public static Order create(OrderStatus orderStatus, OrderType orderType, String comment, Address address, User user, Store store) {
 
         Order order = new Order();
 
         order.orderStatus = orderStatus;
+        order.orderType = orderType;
         order.comment = comment;
         order.address = address;
         order.user = user;

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -1,11 +1,15 @@
 package com.nameplz.baedal.domain.order.domain;
 
 import com.nameplz.baedal.domain.model.BaseEntity;
+import com.nameplz.baedal.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -25,12 +29,26 @@ public class Order extends BaseEntity {
     @Column(name = "comment")
     private String comment;
 
-    public static Order create(String comment) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @BatchSize(size = 500)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderLine> orderLines = new ArrayList<>();
+
+    public static Order create(OrderStatus orderStatus, String comment, User user) {
 
         Order order = new Order();
 
+        order.orderStatus = orderStatus;
         order.comment = comment;
+        order.user = user;
 
         return order;
+    }
+
+    public void addOrderLine(OrderLine orderLine) {
+        orderLines.add(orderLine);
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderLine.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderLine.java
@@ -1,26 +1,21 @@
 package com.nameplz.baedal.domain.order.domain;
 
 import com.nameplz.baedal.domain.model.BaseEntity;
+import com.nameplz.baedal.domain.model.Money;
 import com.nameplz.baedal.domain.store.domain.Product;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Table(name = "p_orderline")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class OrderLine extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -29,7 +24,8 @@ public class OrderLine extends BaseEntity {
     private Integer quantity;
 
     @Column
-    private Integer amount;
+    @Embedded
+    private Money amount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
@@ -39,8 +35,7 @@ public class OrderLine extends BaseEntity {
     @JoinColumn(name = "order_id")
     private Order order;
 
-    public static OrderLine createOrderProduct(
-        Integer quantity, Integer amount, Product product, Order order) {
+    public static OrderLine create(Integer quantity, Money amount, Product product, Order order) {
 
         OrderLine orderProduct = new OrderLine();
         orderProduct.quantity = quantity;

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderStatus.java
@@ -1,9 +1,17 @@
 package com.nameplz.baedal.domain.order.domain;
 
-import jakarta.persistence.Embeddable;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@Embeddable
+@RequiredArgsConstructor
 public enum OrderStatus {
+    PAYMENT_WAITING("결제 대기 중"),
+    ACCEPT_WAITING("접수 대기 중"),
+    COOKING("조리 중"),
+    DELIVERING("배달 중"),
+    DELIVERY_COMPLETED("배달 완료"),
+    CANCELED("주문 취소됨");
+
+    private final String description;
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
@@ -1,0 +1,14 @@
+package com.nameplz.baedal.domain.order.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderType {
+    DELIVERY("배달"),
+    TAKEOUT("포장"),
+    EAT_IN("매장 식사");
+
+    private final String description;
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/repository/OrderRepository.java
@@ -1,0 +1,16 @@
+package com.nameplz.baedal.domain.order.repository;
+
+import com.nameplz.baedal.domain.order.domain.Order;
+import com.nameplz.baedal.domain.store.domain.Store;
+import com.nameplz.baedal.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+    List<Order> findAllByUser(User user);
+
+    List<Order> findAllByStore(Store store);
+}


### PR DESCRIPTION
## 개요
- Order 도메인을 조금 더 기능 추가했습니다. 

## 작업사항
- OrderLine에 쓰일 Money 값객체 추가 
- Order에 쓰일 Address 값객체 추가
- OrderType 추가 
- OrderStatus 세부 내용 추가 
- Order와 연관관계에 있는 User, Store, OrderLine 매핑 
- OrderRepository 추가 

## 관련 이슈
- 
