### PR TITLE
feat: 주문 API 추가 

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
@@ -1,0 +1,99 @@
+package com.nameplz.baedal.domain.order.controller;
+
+import com.nameplz.baedal.domain.order.dto.request.CreateOrderRequestDto;
+import com.nameplz.baedal.domain.order.dto.request.UpdateOrderStatusRequestDto;
+import com.nameplz.baedal.domain.order.dto.response.OrderResponseDto;
+import com.nameplz.baedal.domain.order.service.OrderService;
+import com.nameplz.baedal.global.common.response.CommonResponse;
+import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 주문 단건 조회
+     */
+    @GetMapping("/{orderId}")
+    public CommonResponse<OrderResponseDto> getOrder(@PathVariable(name = "orderId") UUID orderId) {
+        OrderResponseDto response = orderService.getOrder(orderId);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 특정 사용자의 주문 목록 조회
+     * Pageable 예시 : ?page=0&size=10&sort=createdAt,desc
+     */
+    @GetMapping("/users/{userId}")
+    public CommonResponse<List<OrderResponseDto>> getOrderListByUsername(
+            @PathVariable(name = "userId") String userId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        log.info("pageable: {}", pageable);
+        List<OrderResponseDto> response = orderService.getOrderListByUsername(userId, pageable);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 특정 가게의 주문 목록 조회
+     * Pageable 예시 : ?page=0&size=10&sort=createdAt,desc
+     */
+    @GetMapping("/stores/{storeId}")
+    public CommonResponse<List<OrderResponseDto>> getOrderListByStoreId(
+            @PathVariable(name = "storeId") UUID storeId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        List<OrderResponseDto> response = orderService.getOrderListByStoreId(storeId, pageable);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 주문 생성
+     */
+    @PostMapping
+    public CommonResponse<OrderResponseDto> getOrderList(@Valid @RequestBody CreateOrderRequestDto request) {
+        OrderResponseDto response = orderService.createOrder(request);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 주문 상태 변경
+     */
+    @PatchMapping("/{orderId}/status")
+    public CommonResponse<EmptyResponseDto> updateOrderStatus(
+            @PathVariable UUID orderId,
+            @RequestBody UpdateOrderStatusRequestDto request
+    ) {
+        orderService.updateOrderStatus(orderId, request);
+
+        return CommonResponse.success();
+    }
+
+    /**
+     * 주문 취소
+     */
+    @DeleteMapping("/{orderId}")
+    public CommonResponse<EmptyResponseDto> cancelOrder(@PathVariable UUID orderId) {
+        orderService.cancelOrder(orderId);
+
+        return CommonResponse.success();
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
@@ -44,7 +44,6 @@ public class OrderController {
             @PathVariable(name = "userId") String userId,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        log.info("pageable: {}", pageable);
         List<OrderResponseDto> response = orderService.getOrderListByUsername(userId, pageable);
 
         return CommonResponse.success(response);

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -2,6 +2,7 @@ package com.nameplz.baedal.domain.order.domain;
 
 import com.nameplz.baedal.domain.model.Address;
 import com.nameplz.baedal.domain.model.BaseEntity;
+import com.nameplz.baedal.domain.model.Money;
 import com.nameplz.baedal.domain.store.domain.Store;
 import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.global.common.exception.GlobalException;
@@ -69,6 +70,16 @@ public class Order extends BaseEntity {
         order.store = store;
 
         return order;
+    }
+
+    /**
+     * 주문 총 가격 조회
+     */
+    public Money getTotalOrderPrice() {
+
+        return orderLines.stream()
+                .map(OrderLine::getTotalPrice)
+                .reduce(new Money(0), Money::add);
     }
 
     /**

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -109,6 +109,6 @@ public class Order extends BaseEntity {
     }
 
     private boolean isOrderCancelable() {
-        return LocalDateTime.now().isAfter(this.getCreatedAt().plusMinutes(ORDER_CANCELABLE_MINUTES));
+        return LocalDateTime.now().isBefore(this.createdAt.plusMinutes(ORDER_CANCELABLE_MINUTES));
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -4,12 +4,15 @@ import com.nameplz.baedal.domain.model.Address;
 import com.nameplz.baedal.domain.model.BaseEntity;
 import com.nameplz.baedal.domain.store.domain.Store;
 import com.nameplz.baedal.domain.user.domain.User;
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +22,9 @@ import java.util.UUID;
 @Table(name = "p_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
+
+    // 취소 가능한 시간 (분 단위) 변수명
+    private static final int ORDER_CANCELABLE_MINUTES = 5;
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -35,6 +41,7 @@ public class Order extends BaseEntity {
     @Column(name = "comment")
     private String comment;
 
+    @Column
     @Embedded
     private Address address;
 
@@ -64,7 +71,33 @@ public class Order extends BaseEntity {
         return order;
     }
 
+    /**
+     * 주문목록 추가
+     */
     public void addOrderLine(OrderLine orderLine) {
         orderLines.add(orderLine);
+    }
+
+    /**
+     * 주문 상태 변경 - 가게주인과 관리자만 가능
+     */
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        // TODO : 권환 확인 필요
+        this.orderStatus = orderStatus;
+    }
+
+    /**
+     * 주문 취소 - 요구사항에 따라 5분 이내에만 취소 가능
+     */
+    public void cancelOrder() {
+        if (!isOrderCancelable()) {
+            throw new GlobalException(ResultCase.ORDER_CANCEL_DENIED);
+        }
+
+        this.orderStatus = OrderStatus.CANCELED;
+    }
+
+    private boolean isOrderCancelable() {
+        return LocalDateTime.now().isAfter(this.getCreatedAt().plusMinutes(ORDER_CANCELABLE_MINUTES));
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderLine.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderLine.java
@@ -46,4 +46,8 @@ public class OrderLine extends BaseEntity {
 
         return orderProduct;
     }
+
+    public Money getTotalPrice() {
+        return amount.multiply(quantity);
+    }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderStatus.java
@@ -1,11 +1,7 @@
 package com.nameplz.baedal.domain.order.domain;
 
-import com.nameplz.baedal.global.common.exception.GlobalException;
-import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -18,12 +14,4 @@ public enum OrderStatus {
     CANCELED("주문 취소됨");
 
     private final String description;
-
-    public static OrderStatus findByName(String name) {
-
-        return Arrays.stream(OrderStatus.values())
-                .filter(orderStatus -> orderStatus.name().equals(name))
-                .findAny()
-                .orElseThrow(() -> new GlobalException(ResultCase.ORDER_STATUS_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderStatus.java
@@ -1,7 +1,11 @@
 package com.nameplz.baedal.domain.order.domain;
 
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,4 +18,12 @@ public enum OrderStatus {
     CANCELED("주문 취소됨");
 
     private final String description;
+
+    public static OrderStatus findByName(String name) {
+
+        return Arrays.stream(OrderStatus.values())
+                .filter(orderStatus -> orderStatus.name().equals(name))
+                .findAny()
+                .orElseThrow(() -> new GlobalException(ResultCase.ORDER_STATUS_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
@@ -1,11 +1,7 @@
 package com.nameplz.baedal.domain.order.domain;
 
-import com.nameplz.baedal.global.common.exception.GlobalException;
-import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -15,12 +11,4 @@ public enum OrderType {
     OFFLINE("오프라인 주문");
 
     private final String description;
-
-    public static OrderType findByName(String name) {
-
-        return Arrays.stream(OrderType.values())
-                .filter(orderType -> orderType.name().equals(name))
-                .findAny()
-                .orElseThrow(() -> new GlobalException(ResultCase.ORDER_TYPE_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
@@ -1,7 +1,11 @@
 package com.nameplz.baedal.domain.order.domain;
 
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -11,4 +15,12 @@ public enum OrderType {
     OFFLINE("오프라인 주문");
 
     private final String description;
+
+    public static OrderType findByName(String name) {
+
+        return Arrays.stream(OrderType.values())
+                .filter(orderType -> orderType.name().equals(name))
+                .findAny()
+                .orElseThrow(() -> new GlobalException(ResultCase.ORDER_TYPE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/OrderType.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OrderType {
-    DELIVERY("배달"),
-    TAKEOUT("포장"),
-    EAT_IN("매장 식사");
+
+    ONLINE("온라인 주문"),
+    OFFLINE("오프라인 주문");
 
     private final String description;
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderLineRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderLineRequestDto.java
@@ -1,0 +1,10 @@
+package com.nameplz.baedal.domain.order.dto.request;
+
+import java.util.UUID;
+
+public record CreateOrderLineRequestDto(
+        UUID menuId,
+        Integer quantity,
+        Integer price
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderRequestDto.java
@@ -1,0 +1,16 @@
+package com.nameplz.baedal.domain.order.dto.request;
+
+import com.nameplz.baedal.domain.model.Address;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateOrderRequestDto(
+        String orderer,
+        UUID storeId,
+        String orderType,
+        String comment,
+        Address address,
+        List<CreateOrderLineRequestDto> orderLineList
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderRequestDto.java
@@ -1,6 +1,7 @@
 package com.nameplz.baedal.domain.order.dto.request;
 
 import com.nameplz.baedal.domain.model.Address;
+import com.nameplz.baedal.domain.order.domain.OrderType;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,7 +9,7 @@ import java.util.UUID;
 public record CreateOrderRequestDto(
         String orderer,
         UUID storeId,
-        String orderType,
+        OrderType orderType,
         String comment,
         Address address,
         List<CreateOrderLineRequestDto> orderLineList

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/UpdateOrderStatusRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/UpdateOrderStatusRequestDto.java
@@ -1,0 +1,6 @@
+package com.nameplz.baedal.domain.order.dto.request;
+
+public record UpdateOrderStatusRequestDto(
+        String orderStatus
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/UpdateOrderStatusRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/UpdateOrderStatusRequestDto.java
@@ -1,6 +1,8 @@
 package com.nameplz.baedal.domain.order.dto.request;
 
+import com.nameplz.baedal.domain.order.domain.OrderStatus;
+
 public record UpdateOrderStatusRequestDto(
-        String orderStatus
+        OrderStatus orderStatus
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderLineResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderLineResponseDto.java
@@ -1,0 +1,14 @@
+package com.nameplz.baedal.domain.order.dto.response;
+
+import com.nameplz.baedal.domain.model.Money;
+
+import java.util.UUID;
+
+public record OrderLineResponseDto(
+        UUID orderLineId,
+        UUID orderId,
+        UUID productId,
+        Integer quantity,
+        Money amount
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderResponseDto.java
@@ -1,0 +1,20 @@
+package com.nameplz.baedal.domain.order.dto.response;
+
+import com.nameplz.baedal.domain.model.Address;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderResponseDto(
+        UUID orderId,
+        String orderStatus,
+        String orderType,
+        String comment,
+        Address address,
+        String userId,
+        UUID storeId,
+        List<OrderLineResponseDto> orderLineList,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/mapper/OrderMapper.java
@@ -1,0 +1,24 @@
+package com.nameplz.baedal.domain.order.mapper;
+
+import com.nameplz.baedal.domain.order.domain.Order;
+import com.nameplz.baedal.domain.order.domain.OrderLine;
+import com.nameplz.baedal.domain.order.dto.response.OrderLineResponseDto;
+import com.nameplz.baedal.domain.order.dto.response.OrderResponseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING)
+public interface OrderMapper {
+
+    @Mapping(target = "orderLineId", source = "orderLine.id")
+    OrderLineResponseDto toOrderLineResponseDto(OrderLine orderLine);
+
+    @Mapping(target = "orderId", source = "order.id")
+    @Mapping(
+            target = "orderLineList",
+            expression = "java(order.getOrderLines().stream().map(orderLine -> toOrderLineResponseDto(orderLine)).toList())"
+    )
+    OrderResponseDto toOrderResponseDto(Order order);
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/repository/OrderRepository.java
@@ -1,8 +1,7 @@
 package com.nameplz.baedal.domain.order.repository;
 
 import com.nameplz.baedal.domain.order.domain.Order;
-import com.nameplz.baedal.domain.store.domain.Store;
-import com.nameplz.baedal.domain.user.domain.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,7 +9,12 @@ import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
 
-    List<Order> findAllByUser(User user);
+    /**
+     * Pageable 인터페이스를 이용하여 페이징 처리
+     * List 타입으로 반환하여 count 쿼리를 실행하지 않게 함
+     * (Page 타입으로 반환하면 count 쿼리를 추가로 실행하여 성능 저하가 발생할 수 있음)
+     */
+    List<Order> findAllByUser_UsernameAndDeletedAtIsNull(String username, Pageable pageable);
 
-    List<Order> findAllByStore(Store store);
+    List<Order> findAllByStore_IdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/service/OrderService.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/service/OrderService.java
@@ -1,0 +1,134 @@
+package com.nameplz.baedal.domain.order.service;
+
+import com.nameplz.baedal.domain.model.Money;
+import com.nameplz.baedal.domain.order.domain.Order;
+import com.nameplz.baedal.domain.order.domain.OrderLine;
+import com.nameplz.baedal.domain.order.domain.OrderStatus;
+import com.nameplz.baedal.domain.order.domain.OrderType;
+import com.nameplz.baedal.domain.order.dto.request.CreateOrderRequestDto;
+import com.nameplz.baedal.domain.order.dto.request.UpdateOrderStatusRequestDto;
+import com.nameplz.baedal.domain.order.dto.response.OrderResponseDto;
+import com.nameplz.baedal.domain.order.mapper.OrderMapper;
+import com.nameplz.baedal.domain.order.repository.OrderRepository;
+import com.nameplz.baedal.domain.store.domain.Store;
+import com.nameplz.baedal.domain.user.domain.User;
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderMapper mapper;
+    private final OrderRepository orderRepository;
+
+    /**
+     * 주문 단건 조회
+     */
+    public OrderResponseDto getOrder(UUID orderId) {
+
+        Order order = findOrder(orderId);
+        return mapper.toOrderResponseDto(order);
+    }
+
+    /**
+     * 특정 사용자의 주문 목록 조회
+     */
+    public List<OrderResponseDto> getOrderListByUsername(String username, Pageable pageable) {
+
+        return orderRepository.findAllByUser_UsernameAndDeletedAtIsNull(username, pageable)
+                .stream()
+                .map(mapper::toOrderResponseDto)
+                .toList();
+    }
+
+    /**
+     * 특정 가게의 주문 목록 조회
+     */
+    public List<OrderResponseDto> getOrderListByStoreId(UUID storeId, Pageable pageable) {
+
+        return orderRepository.findAllByStore_IdAndDeletedAtIsNull(storeId, pageable)
+                .stream()
+                .map(mapper::toOrderResponseDto)
+                .toList();
+    }
+
+    /**
+     * 주문 생성
+     */
+    @Transactional
+    public OrderResponseDto createOrder(CreateOrderRequestDto requestDto) {
+
+        // TODO : 주문자 조회
+        // TODO : 가게 조회
+
+        Order order = createOrderEntity(requestDto, null, null);
+        addOrderLineListInOrder(requestDto, order);
+
+        Order savedOrder = orderRepository.save(order);
+
+        return mapper.toOrderResponseDto(savedOrder);
+    }
+
+    private Order createOrderEntity(CreateOrderRequestDto requestDto, User user, Store store) {
+
+        OrderType orderType = OrderType.findByName(requestDto.orderType());
+
+        return Order.create(
+                OrderStatus.PAYMENT_WAITING,
+                orderType,
+                requestDto.comment(),
+                requestDto.address(),
+                user,
+                store
+        );
+    }
+
+    private void addOrderLineListInOrder(CreateOrderRequestDto request, Order order) {
+        request.orderLineList()
+                .stream()
+                .map(orderLineDto -> OrderLine.create(
+                        orderLineDto.quantity(),
+                        new Money(orderLineDto.price()),
+                        null,
+                        order))
+                .forEach(order::addOrderLine);
+    }
+
+    /**
+     * 주문 상태 변경
+     */
+    @Transactional
+    public void updateOrderStatus(UUID orderId, UpdateOrderStatusRequestDto request) {
+
+        OrderStatus orderStatus = OrderStatus.findByName(request.orderStatus());
+
+        Order order = findOrder(orderId);
+        order.updateOrderStatus(orderStatus);
+    }
+
+    /**
+     * 주문 삭제
+     */
+    @Transactional
+    public void cancelOrder(UUID orderId) {
+
+        Order order = findOrder(orderId);
+        order.cancelOrder();
+    }
+
+    private Order findOrder(UUID orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new GlobalException(ResultCase.ORDER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/service/OrderService.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/service/OrderService.java
@@ -4,7 +4,6 @@ import com.nameplz.baedal.domain.model.Money;
 import com.nameplz.baedal.domain.order.domain.Order;
 import com.nameplz.baedal.domain.order.domain.OrderLine;
 import com.nameplz.baedal.domain.order.domain.OrderStatus;
-import com.nameplz.baedal.domain.order.domain.OrderType;
 import com.nameplz.baedal.domain.order.dto.request.CreateOrderRequestDto;
 import com.nameplz.baedal.domain.order.dto.request.UpdateOrderStatusRequestDto;
 import com.nameplz.baedal.domain.order.dto.response.OrderResponseDto;
@@ -82,11 +81,9 @@ public class OrderService {
 
     private Order createOrderEntity(CreateOrderRequestDto requestDto, User user, Store store) {
 
-        OrderType orderType = OrderType.findByName(requestDto.orderType());
-
         return Order.create(
                 OrderStatus.PAYMENT_WAITING,
-                orderType,
+                requestDto.orderType(),
                 requestDto.comment(),
                 requestDto.address(),
                 user,
@@ -111,10 +108,8 @@ public class OrderService {
     @Transactional
     public void updateOrderStatus(UUID orderId, UpdateOrderStatusRequestDto request) {
 
-        OrderStatus orderStatus = OrderStatus.findByName(request.orderStatus());
-
         Order order = findOrder(orderId);
-        order.updateOrderStatus(orderStatus);
+        order.updateOrderStatus(request.orderStatus());
     }
 
     /**

--- a/src/main/java/com/nameplz/baedal/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nameplz/baedal/global/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import com.nameplz.baedal.global.common.response.EmptyResponseDto;
 import com.nameplz.baedal.global.common.response.ResultCase;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,6 +16,7 @@ import java.util.List;
 /**
  * 전역 예외 처리 핸들러
  */
+@Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
@@ -29,6 +32,16 @@ public class GlobalExceptionHandler {
         response.setStatus(e.getResultCase().getHttpStatus().value()); // HttpStatus 설정
 
         return CommonResponse.error(e.getResultCase()); // 공통 응답 양식 반환
+    }
+
+    /**
+     * RequestBody 입력 파라미터가 없거나 형식이 맞지 않을 때 발생하는 오류에 대한 핸들러
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public CommonResponse<EmptyResponseDto> handleGlobalException(HttpMessageNotReadableException e) {
+        response.setStatus(ResultCase.INVALID_INPUT.getHttpStatus().value()); // HttpStatus 설정
+
+        return CommonResponse.error(ResultCase.INVALID_INPUT); // 공통 응답 양식 반환
     }
 
     /**

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -8,10 +8,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ResultCase {
 
-    // 성공 0번대 - 모든 성공 응답을 200으로 통일
+    /* 성공 0번대 - 모든 성공 응답을 200으로 통일 */
     SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다"),
 
-    // 글로벌 1000번대
+    /* 글로벌 1000번대 */
 
     // 권한 없음 403
     NOT_AUTHORIZED(HttpStatus.FORBIDDEN, 1000, "해당 요청에 대한 권한이 없습니다."),
@@ -20,7 +20,7 @@ public enum ResultCase {
     // 시스템 에러 500
     SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1002, "알 수 없는 에러가 발생했습니다."),
 
-    // 유저 2000번대
+    /* 유저 2000번대 */
 
     // 존재하지 않는 사용자 404,
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2000, "유저를 찾을 수 없습니다."),
@@ -28,7 +28,18 @@ public enum ResultCase {
     NOT_FOUND(HttpStatus.NOT_FOUND, 2002, "존재하지 않는 입력값입니다."),
 
     // 로그인 필요 401
-    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 2001, "로그인이 필요합니다.");
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 2001, "로그인이 필요합니다."),
+
+    /* 주문 3000번대 */
+
+    // 존재하지 않는 주문 타입 404
+    ORDER_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, 3000, "주문 타입을 찾을 수 없습니다."),
+    // 존재하지 않는 주문 상태 404
+    ORDER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, 3001, "주문 타입을 찾을 수 없습니다."),
+    // 존재하지 않는 주문 404
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, 3002, "주문을 찾을 수 없습니다."),
+    // 주문 취소 불가 400
+    ORDER_CANCEL_DENIED(HttpStatus.BAD_REQUEST, 3003, "주문을 취소할 수 없습니다.");
 
     private final HttpStatus httpStatus; // 응답 상태 코드
     private final Integer code; // 응답 코드. 도메인에 따라 1000번대로 나뉨


### PR DESCRIPTION
## 개요
- 주문 도메인의 API를 추가했습니다. 

## 작업사항
- 주문 상태 및 유형 ENUM에 name으로 조회하는 메서드 추가 
  - 상태와 행위를 한 곳에 두어 응집도를 높였습니다. 
- 목록 조회 페이지네이션 적용
  - 현재는 오프셋 기반이나, 추후 커서 기반으로 변경 예정 
- API 목록 
  - 주문 단건 조회
  - 주문 목록 조회 (username)
  - 주문 목록 조회 (store id)
  - 주문 생성
  - 주문 상태 변경
  - 주문 취소

## 관련 이슈
- 

## 기타사항
- 조금 분량이 많네요,, 조절 실패 죄송합니다 ㅠ
- Validation 처리도 이후에 하겠습니다..!