### PR TITLE
feat: 리뷰 도메인 추가 

### DIFF
--- a/http/review/review-api.http
+++ b/http/review/review-api.http
@@ -1,0 +1,12 @@
+GET http://localhost:8080/reviews/orders/f0c55630-eabb-41d0-8545-7b843071288f
+
+###
+
+POST http://localhost:8080/reviews/orders/f0c55630-eabb-41d0-8545-7b843071288f
+Content-Type: application/json
+
+{
+  "rating": 5,
+  "content": "Great service!",
+  "isReported": false
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/controller/ReviewController.java
@@ -34,7 +34,7 @@ public class ReviewController {
     @GetMapping("/orders/{orderId}")
     public CommonResponse<ReviewResponseDto> getReview(@PathVariable UUID orderId) {
 
-        ReviewResponseDto response = reviewService.getReviewByOrderId(orderId);
+        ReviewResponseDto response = reviewService.getReviewByOrderIdWithoutDeleted(orderId);
 
         return CommonResponse.success(response);
     }
@@ -48,7 +48,7 @@ public class ReviewController {
             @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable
     ) {
 
-        List<ReviewResponseDto> response = reviewService.getReviewListByUsername(userId, pageable);
+        List<ReviewResponseDto> response = reviewService.getReviewListByUsernameWithoutDeleted(userId, pageable);
 
         return CommonResponse.success(response);
     }
@@ -62,7 +62,7 @@ public class ReviewController {
             @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable
     ) {
 
-        List<ReviewResponseDto> response = reviewService.getReviewListByStoreId(storeId);
+        List<ReviewResponseDto> response = reviewService.getReviewListByStoreIdWithoutDeleted(storeId, pageable);
 
         return CommonResponse.success(response);
     }

--- a/src/main/java/com/nameplz/baedal/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/controller/ReviewController.java
@@ -1,0 +1,110 @@
+package com.nameplz.baedal.domain.review.controller;
+
+import com.nameplz.baedal.domain.review.dto.request.CreateReviewRequestDto;
+import com.nameplz.baedal.domain.review.dto.request.UpdateReviewRequestDto;
+import com.nameplz.baedal.domain.review.dto.response.ReviewResponseDto;
+import com.nameplz.baedal.domain.review.service.ReviewService;
+import com.nameplz.baedal.global.common.response.CommonResponse;
+import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@Slf4j
+@Tag(name = "리뷰")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 주문 아이디로 리뷰 단건 조회
+     */
+    @GetMapping("/orders/{orderId}")
+    public CommonResponse<ReviewResponseDto> getReview(@PathVariable UUID orderId) {
+
+        ReviewResponseDto response = reviewService.getReviewByOrderId(orderId);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 유저 아이디로 리뷰 리스트 조회
+     */
+    @GetMapping("/users/{userId}")
+    public CommonResponse<List<ReviewResponseDto>> getReview(
+            @PathVariable String userId,
+            @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable
+    ) {
+
+        List<ReviewResponseDto> response = reviewService.getReviewListByUsername(userId, pageable);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 가게 아이디로 리뷰 리스트 조회
+     */
+    @GetMapping("/stores/{storeId}")
+    public CommonResponse<List<ReviewResponseDto>> getReview(
+            @PathVariable UUID storeId,
+            @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable
+    ) {
+
+        List<ReviewResponseDto> response = reviewService.getReviewListByStoreId(storeId);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 리뷰 생성
+     */
+    @PostMapping("/orders/{orderId}")
+    public CommonResponse<ReviewResponseDto> createReview(
+            @PathVariable UUID orderId,
+            @Validated @RequestBody CreateReviewRequestDto request
+    ) {
+
+        // TODO : 유저 가져오기
+        ReviewResponseDto response = reviewService.createReview(request, "username", orderId);
+
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 리뷰 수정
+     */
+    @PutMapping("/{reviewId}")
+    public CommonResponse<EmptyResponseDto> updateReview(
+            @PathVariable UUID reviewId,
+            @Validated @RequestBody UpdateReviewRequestDto request
+    ) {
+
+        reviewService.updateReview(request, reviewId);
+
+        return CommonResponse.success();
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @DeleteMapping("/{reviewId}")
+    public CommonResponse<EmptyResponseDto> deleteReview(@PathVariable UUID reviewId) {
+
+        // TODO : 유저 가져오기
+        reviewService.deleteReview(reviewId, "username");
+
+        return CommonResponse.success();
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/domain/Rating.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/domain/Rating.java
@@ -1,0 +1,33 @@
+package com.nameplz.baedal.domain.review.domain;
+
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Rating {
+
+    private static final int MIN_SCORE = 1;
+    private static final int MAX_SCORE = 5;
+
+    private Integer score;
+
+    public Rating(int score) {
+        if (!isScoreInRange(score)) {
+            throw new GlobalException(ResultCase.INVALID_INPUT);
+        }
+
+        this.score = score;
+    }
+
+    private boolean isScoreInRange(int score) {
+        return MIN_SCORE <= score && score <= MAX_SCORE;
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
@@ -1,7 +1,8 @@
 package com.nameplz.baedal.domain.review.domain;
 
 import com.nameplz.baedal.domain.model.BaseEntity;
-import com.nameplz.baedal.domain.store.domain.Store;
+import com.nameplz.baedal.domain.order.domain.Order;
+import com.nameplz.baedal.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,18 +31,29 @@ public class Review extends BaseEntity {
     private boolean isReported;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "store_id")
-    private Store store;
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    public static Review create(String content, Integer rating, Store store) {
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    public static Review create(String content, Rating rating, boolean isReported, User user, Order order) {
 
         Review review = new Review();
 
         review.content = content;
         review.rating = rating;
-        review.isReported = false;
-        review.store = store;
+        review.isReported = isReported;
+        review.user = user;
+        review.order = order;
 
         return review;
+    }
+
+    public void update(Rating rating, boolean isReported, String content) {
+        this.rating = rating;
+        this.isReported = isReported;
+        this.content = content;
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/domain/Review.java
@@ -23,7 +23,8 @@ public class Review extends BaseEntity {
     private String content;
 
     @Column(name = "rating")
-    private Integer rating;
+    @Embedded
+    private Rating rating;
 
     @Column(name = "is_reported")
     private boolean isReported;

--- a/src/main/java/com/nameplz/baedal/domain/review/dto/request/CreateReviewRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/dto/request/CreateReviewRequestDto.java
@@ -1,0 +1,20 @@
+package com.nameplz.baedal.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+
+public record CreateReviewRequestDto(
+
+        @NotBlank(message = "리뷰 내용은 필수입니다.")
+        @Length(max = 1000, message = "리뷰 내용은 1000자 이하여야 합니다.")
+        String content,
+
+        @Range(min = 1, max = 5, message = "평점은 1~5 사이어야 합니다.")
+        Integer rating,
+
+        @NotNull(message = "신고 여부는 필수입니다.")
+        Boolean isReported
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/dto/request/UpdateReviewRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/dto/request/UpdateReviewRequestDto.java
@@ -1,0 +1,20 @@
+package com.nameplz.baedal.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+
+public record UpdateReviewRequestDto(
+
+        @NotBlank(message = "리뷰 내용은 필수입니다.")
+        @Length(max = 1000, message = "리뷰 내용은 1000자 이하여야 합니다.")
+        String content,
+
+        @Range(min = 1, max = 5, message = "평점은 1~5 사이어야 합니다.")
+        Integer rating,
+
+        @NotNull(message = "신고 여부는 필수입니다.")
+        Boolean isReported
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/dto/response/ReviewResponseDto.java
@@ -1,0 +1,15 @@
+package com.nameplz.baedal.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReviewResponseDto(
+        UUID id,
+        UUID orderId,
+        String username,
+        String content,
+        Integer rating,
+        boolean isReported,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/mapper/ReviewMapper.java
@@ -1,0 +1,17 @@
+package com.nameplz.baedal.domain.review.mapper;
+
+import com.nameplz.baedal.domain.review.domain.Review;
+import com.nameplz.baedal.domain.review.dto.response.ReviewResponseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING)
+public interface ReviewMapper {
+
+    @Mapping(target = "orderId", source = "order.id")
+    @Mapping(target = "rating", source = "rating.score")
+    @Mapping(target = "username", source = "user.username")
+    ReviewResponseDto toReviewResponseDto(Review review);
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewCustomRepository.java
@@ -1,0 +1,16 @@
+package com.nameplz.baedal.domain.review.repository;
+
+import com.nameplz.baedal.domain.review.domain.Review;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ReviewCustomRepository {
+
+    Review findByOrderIdWithoutDeleted(UUID orderId);
+
+    List<Review> findAllByUsernameWithoutDeleted(String username, Pageable pageable);
+
+    List<Review> findAllByStoreIdWithoutDeleted(UUID storeId, Pageable pageable);
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewCustomRepositoryImpl.java
@@ -1,0 +1,127 @@
+package com.nameplz.baedal.domain.review.repository;
+
+import com.nameplz.baedal.domain.review.domain.Review;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.nameplz.baedal.domain.review.domain.QReview.review;
+
+@RequiredArgsConstructor
+public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
+
+    private final JPAQueryFactory query;
+
+    /**
+     * 주문 아이디로 리뷰 단건 조회
+     */
+    @Override
+    public Review findByOrderIdWithoutDeleted(UUID orderId) {
+
+        return query
+                .selectFrom(review)
+                .where(isReviewNotDeleted(), isOrderIdEqualTo(orderId), isOrderNotDeleted())
+                .fetchOne();
+    }
+
+    private BooleanExpression isOrderIdEqualTo(UUID orderId) {
+        return review.order.id.eq(orderId);
+    }
+
+    /**
+     * 유저 아이디로 리뷰 리스트 조회
+     */
+    @Override
+    public List<Review> findAllByUsernameWithoutDeleted(String username, Pageable pageable) {
+
+        JPAQuery<Review> jpaQuery = query
+                .selectFrom(review)
+                .leftJoin(review.user)
+                .fetchJoin()
+                .where(isReviewNotDeleted(), isUserNotDeleted(), isUsernameEqualTo(username))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        pageable.getSort().forEach(order -> jpaQuery.orderBy(createOrderSpecifier(order)));
+
+        return jpaQuery.fetch();
+    }
+
+    private BooleanExpression isUsernameEqualTo(String username) {
+        return review.user.username.eq(username);
+    }
+
+    /**
+     * 가게 아이디로 리뷰 리스트 조회 - 리뷰 평점 조회용
+     */
+    @Override
+    public List<Review> findAllByStoreIdWithoutDeleted(UUID storeId, Pageable pageable) {
+
+
+        JPAQuery<Review> jpaQuery = query
+                .selectFrom(review)
+                .leftJoin(review.order.store)
+                .fetchJoin()
+                .where(
+                        isReviewNotDeleted(),
+                        isStoreNotDeleted(),
+                        isReportedFalse(),
+                        isStoreIdEqualTo(storeId)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        pageable.getSort().forEach(order -> jpaQuery.orderBy(createOrderSpecifier(order)));
+
+        return jpaQuery.fetch();
+    }
+
+    private BooleanExpression isReportedFalse() {
+        return review.isReported.isFalse();
+    }
+
+    private BooleanExpression isStoreIdEqualTo(UUID storeId) {
+        return review.order.store.id.eq(storeId);
+    }
+
+    /**
+     * 생성일, 수정일 기준으로 정렬 조건을 생성
+     * 기본값은 생성일 내림차순
+     */
+    private OrderSpecifier<LocalDateTime> createOrderSpecifier(Sort.Order order) {
+
+        String sortType = order.getProperty(); // 정렬 기준 필드
+        Order orderDirection = order.isAscending() ? Order.ASC : Order.DESC; // 정렬 방향
+
+        return switch (sortType) {
+            case "createdAt" -> new OrderSpecifier<>(orderDirection, review.createdAt);
+            case "updatedAt" -> new OrderSpecifier<>(orderDirection, review.updatedAt);
+            default -> new OrderSpecifier<>(Order.DESC, review.createdAt);
+        };
+    }
+
+    private BooleanExpression isOrderNotDeleted() {
+        return review.order.deletedAt.isNull();
+    }
+
+    private BooleanExpression isUserNotDeleted() {
+        return review.user.deletedAt.isNull();
+    }
+
+    private BooleanExpression isStoreNotDeleted() {
+        return review.order.store.deletedAt.isNull();
+    }
+
+    private BooleanExpression isReviewNotDeleted() {
+        return review.deletedAt.isNull();
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,23 @@
+package com.nameplz.baedal.domain.review.repository;
+
+import com.nameplz.baedal.domain.review.domain.Review;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
+    Review findByOrder_IdAndDeletedAtIsNull(UUID orderId);
+
+    List<Review> findAllByUser_UsernameAndDeletedAtIsNull(String username, Pageable pageable);
+
+    /**
+     * 특정 가게의 모든 리뷰를 조회
+     * Review 엔티티의 Rating 값객체를 이용하여 평균 평점을 계산
+     */
+    @Query("select r from Review r inner join fetch Order o on r.order = o where o.store.id = :storeId and o.deletedAt is null and r.deletedAt is null and r.isReported = false")
+    List<Review> findAllReviewsByStoreId(UUID storeId);
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/repository/ReviewRepository.java
@@ -3,21 +3,13 @@ package com.nameplz.baedal.domain.review.repository;
 import com.nameplz.baedal.domain.review.domain.Review;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface ReviewRepository extends JpaRepository<Review, UUID> {
+public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewCustomRepository {
 
-    Review findByOrder_IdAndDeletedAtIsNull(UUID orderId);
+    Review findByOrderId(UUID orderId);
 
-    List<Review> findAllByUser_UsernameAndDeletedAtIsNull(String username, Pageable pageable);
-
-    /**
-     * 특정 가게의 모든 리뷰를 조회
-     * Review 엔티티의 Rating 값객체를 이용하여 평균 평점을 계산
-     */
-    @Query("select r from Review r inner join fetch Order o on r.order = o where o.store.id = :storeId and o.deletedAt is null and r.deletedAt is null and r.isReported = false")
-    List<Review> findAllReviewsByStoreId(UUID storeId);
+    List<Review> findAllByUser_Username(String username, Pageable pageable);
 }

--- a/src/main/java/com/nameplz/baedal/domain/review/service/ReviewService.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/service/ReviewService.java
@@ -1,0 +1,103 @@
+package com.nameplz.baedal.domain.review.service;
+
+import com.nameplz.baedal.domain.review.domain.Rating;
+import com.nameplz.baedal.domain.review.domain.Review;
+import com.nameplz.baedal.domain.review.dto.request.CreateReviewRequestDto;
+import com.nameplz.baedal.domain.review.dto.request.UpdateReviewRequestDto;
+import com.nameplz.baedal.domain.review.dto.response.ReviewResponseDto;
+import com.nameplz.baedal.domain.review.mapper.ReviewMapper;
+import com.nameplz.baedal.domain.review.repository.ReviewRepository;
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewMapper mapper;
+    private final ReviewRepository reviewRepository;
+
+    /**
+     * 주문 아이디로 리뷰 단건 조회
+     */
+    public ReviewResponseDto getReviewByOrderId(UUID orderId) {
+        Review review = reviewRepository.findByOrder_IdAndDeletedAtIsNull(orderId);
+        return mapper.toReviewResponseDto(review);
+    }
+
+    /**
+     * 유저 아이디로 리뷰 리스트 조회
+     */
+    public List<ReviewResponseDto> getReviewListByUsername(String username, Pageable pageable) {
+
+        return reviewRepository.findAllByUser_UsernameAndDeletedAtIsNull(username, pageable)
+                .stream()
+                .map(mapper::toReviewResponseDto)
+                .toList();
+    }
+
+    /**
+     * 가게 아이디로 리뷰 리스트 조회
+     */
+    public List<ReviewResponseDto> getReviewListByStoreId(UUID storeId) {
+
+        return reviewRepository.findAllReviewsByStoreId(storeId)
+                .stream()
+                .map(mapper::toReviewResponseDto)
+                .toList();
+    }
+
+    /**
+     * 리뷰 생성
+     */
+    @Transactional
+    public ReviewResponseDto createReview(CreateReviewRequestDto request, String username, UUID orderId) {
+
+        // TODO : 유저 가져오기
+        // TODO : 주문 가져오기
+
+        Review review = Review.create(
+                request.content(),
+                new Rating(request.rating()),
+                request.isReported(),
+                null,
+                null);
+
+        Review savedReview = reviewRepository.save(review);
+
+        return mapper.toReviewResponseDto(savedReview);
+    }
+
+    /**
+     * 리뷰 수정
+     */
+    @Transactional
+    public void updateReview(UpdateReviewRequestDto request, UUID reviewId) {
+        Review review = findReviewById(reviewId);
+        review.update(new Rating(request.rating()), request.isReported(), request.content());
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @Transactional
+    public void deleteReview(UUID reviewId, String username) {
+        Review review = findReviewById(reviewId);
+        review.deleteEntity(username);
+    }
+
+    private Review findReviewById(UUID reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new GlobalException(ResultCase.REVIEW_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/review/service/ReviewService.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/service/ReviewService.java
@@ -28,19 +28,38 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
 
     /**
-     * 주문 아이디로 리뷰 단건 조회
+     * 주문 아이디로 리뷰 단건 조회 - 삭제되지 않은 리뷰만 조회
      */
-    public ReviewResponseDto getReviewByOrderId(UUID orderId) {
-        Review review = reviewRepository.findByOrder_IdAndDeletedAtIsNull(orderId);
+    public ReviewResponseDto getReviewByOrderIdWithoutDeleted(UUID orderId) {
+        Review review = reviewRepository.findByOrderIdWithoutDeleted(orderId);
+        return mapper.toReviewResponseDto(review);
+    }
+
+    /**
+     * 주문 아이디로 리뷰 단건 조회 - 삭제된 리뷰도 조회
+     */
+    public ReviewResponseDto getReviewByOrderIdWithDeleted(UUID orderId) {
+        Review review = reviewRepository.findByOrderId(orderId);
         return mapper.toReviewResponseDto(review);
     }
 
     /**
      * 유저 아이디로 리뷰 리스트 조회
      */
-    public List<ReviewResponseDto> getReviewListByUsername(String username, Pageable pageable) {
+    public List<ReviewResponseDto> getReviewListByUsernameWithoutDeleted(String username, Pageable pageable) {
 
-        return reviewRepository.findAllByUser_UsernameAndDeletedAtIsNull(username, pageable)
+        return reviewRepository.findAllByUsernameWithoutDeleted(username, pageable)
+                .stream()
+                .map(mapper::toReviewResponseDto)
+                .toList();
+    }
+
+    /**
+     * 유저 아이디로 리뷰 리스트 조회
+     */
+    public List<ReviewResponseDto> getReviewListByUsernameWithDeleted(String username, Pageable pageable) {
+
+        return reviewRepository.findAllByUser_Username(username, pageable)
                 .stream()
                 .map(mapper::toReviewResponseDto)
                 .toList();
@@ -49,9 +68,9 @@ public class ReviewService {
     /**
      * 가게 아이디로 리뷰 리스트 조회
      */
-    public List<ReviewResponseDto> getReviewListByStoreId(UUID storeId) {
+    public List<ReviewResponseDto> getReviewListByStoreIdWithoutDeleted(UUID storeId, Pageable pageable) {
 
-        return reviewRepository.findAllReviewsByStoreId(storeId)
+        return reviewRepository.findAllByStoreIdWithoutDeleted(storeId, pageable)
                 .stream()
                 .map(mapper::toReviewResponseDto)
                 .toList();

--- a/src/main/java/com/nameplz/baedal/domain/store/domain/Store.java
+++ b/src/main/java/com/nameplz/baedal/domain/store/domain/Store.java
@@ -2,30 +2,17 @@ package com.nameplz.baedal.domain.store.domain;
 
 import com.nameplz.baedal.domain.category.domain.Category;
 import com.nameplz.baedal.domain.model.BaseEntity;
-import com.nameplz.baedal.domain.review.domain.Review;
 import com.nameplz.baedal.domain.territory.domain.Territory;
 import com.nameplz.baedal.domain.user.domain.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Table(name = "p_store")
 @Getter
@@ -66,12 +53,9 @@ public class Store extends BaseEntity {
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
     private List<Product> productList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "store")
-    private List<Review> reviewList = new ArrayList<>();
-
     public static Store createStore(
-        String title, String description, String image, User user, Territory territory,
-        Category category) {
+            String title, String description, String image, User user, Territory territory,
+            Category category) {
         Store store = new Store();
         // 필드 값
         store.title = title;
@@ -99,8 +83,8 @@ public class Store extends BaseEntity {
      * 가게 업데이트
      */
     public void updateStore(String title, String description, String image, StoreStatus status,
-        Territory territory,
-        Category category) {
+                            Territory territory,
+                            Category category) {
         this.title = title;
         this.description = description;
         this.image = image;

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -44,7 +44,11 @@ public enum ResultCase {
     /* 결제 4000번대 */
 
     // 결제 정보를 찾을 수 없음 404
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "결제 정보를 찾을 수 없습니다.");
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "결제 정보를 찾을 수 없습니다."),
+
+    /* 리뷰 5000번대 */
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, 5000, "리뷰를 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus; // 응답 상태 코드
     private final Integer code; // 응답 코드. 도메인에 따라 1000번대로 나뉨


### PR DESCRIPTION
## 개요
- 리뷰 도메인을 추가했습니다. 

## 작업사항
- 가게의 연관관계를 주문으로 이동 
- 리뷰 평점 값객체 추가 
- API 목록 
  - 주문 id로 리뷰 단건 조회
  - 유저 id로 리뷰 목록 조회
  - 가게 id로 리뷰 목록 조회
  - 리뷰 생성
  - 리뷰 수정
  - 리뷰 삭제

## 관련 이슈
- 
