### PR TITLE
feat: category 및 territory 에서 삭제 된 경우 store 및 product 접근 제어

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/category/repository/CategoryRepository.java
@@ -9,4 +9,6 @@ public interface CategoryRepository extends JpaRepository<Category, UUID>,
     CategoryCustomRepository {
 
     Optional<Category> findByName(String name);
+
+    Optional<Category> findByIdAndDeletedAtIsNull(UUID categoryId);
 }

--- a/src/main/java/com/nameplz/baedal/domain/category/service/CategoryService.java
+++ b/src/main/java/com/nameplz/baedal/domain/category/service/CategoryService.java
@@ -69,7 +69,7 @@ public class CategoryService {
     // 카테고리 Id 찾는 함수
     private Category findCategoryById(UUID categoryId) {
         return categoryRepository.findById(categoryId)
-            .orElseThrow(() -> new GlobalException(ResultCase.INVALID_INPUT));
+            .orElseThrow(() -> new GlobalException(ResultCase.CATEGORY_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/nameplz/baedal/domain/store/repository/ProductRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/store/repository/ProductRepository.java
@@ -2,6 +2,7 @@ package com.nameplz.baedal.domain.store.repository;
 
 import com.nameplz.baedal.domain.store.domain.Product;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface ProductRepository extends JpaRepository<Product, UUID>, Product
      */
     List<Product> findAllByStoreIdAndIsPublicAndDeletedAtIsNull(UUID storeId, boolean isPublic,
         Pageable pageable);
+
+    Optional<Product> findByIdAndDeletedAtIsNull(UUID productId);
 }

--- a/src/main/java/com/nameplz/baedal/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/store/repository/StoreRepository.java
@@ -1,9 +1,11 @@
 package com.nameplz.baedal.domain.store.repository;
 
 import com.nameplz.baedal.domain.store.domain.Store;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, UUID>, StoreCustomRepository {
 
+    Optional<Store> findByIdAndDeletedAtIsNull(UUID storeId);
 }

--- a/src/main/java/com/nameplz/baedal/domain/store/service/ProductService.java
+++ b/src/main/java/com/nameplz/baedal/domain/store/service/ProductService.java
@@ -170,15 +170,15 @@ public class ProductService {
      * Id 별로 있는지 확인 후 불러오는 함수 모음
      */
     private Store findStoreById(UUID storeId) {
-        return storeRepository.findById(storeId)
+        return storeRepository.findByIdAndDeletedAtIsNull(storeId)
             .orElseThrow(() -> new GlobalException(
-                ResultCase.INVALID_INPUT));
+                ResultCase.STORE_NOT_FOUND));
     }
 
     private Product findProductByIdAndCheck(UUID productId) {
-        return productRepository.findById(productId)
+        return productRepository.findByIdAndDeletedAtIsNull(productId)
             .orElseThrow(() -> new GlobalException(
-                ResultCase.INVALID_INPUT));
+                ResultCase.PRODUCT_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/nameplz/baedal/domain/store/service/StoreService.java
+++ b/src/main/java/com/nameplz/baedal/domain/store/service/StoreService.java
@@ -170,20 +170,20 @@ public class StoreService {
     }
 
     private Store findStoreByIdAndCheck(UUID storeId) {
-        return storeRepository.findById(storeId)
-            .orElseThrow(() -> new GlobalException(ResultCase.INVALID_INPUT));
+        return storeRepository.findByIdAndDeletedAtIsNull(storeId)
+            .orElseThrow(() -> new GlobalException(ResultCase.STORE_NOT_FOUND));
     }
 
     private Territory findTerritoryByIdAndCheck(UUID territoryId) {
-        return territoryRepository.findById(territoryId)
+        return territoryRepository.findByIdAndDeletedAtIsNull(territoryId)
             .orElseThrow(() -> new GlobalException(
-                ResultCase.INVALID_INPUT));
+                ResultCase.TERRITORY_NOT_FOUND));
     }
 
     private Category findCategoryByIdAndCheck(UUID categoryId) {
-        return categoryRepository.findById(categoryId)
+        return categoryRepository.findByIdAndDeletedAtIsNull(categoryId)
             .orElseThrow(() -> new GlobalException(
-                ResultCase.INVALID_INPUT));
+                ResultCase.CATEGORY_NOT_FOUND));
     }
 
 

--- a/src/main/java/com/nameplz/baedal/domain/territory/controller/TerritoryController.java
+++ b/src/main/java/com/nameplz/baedal/domain/territory/controller/TerritoryController.java
@@ -9,8 +9,6 @@ import com.nameplz.baedal.global.common.response.CommonResponse;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,13 +31,11 @@ public class TerritoryController {
      * territory 생성
      */
     @PostMapping
-    public ResponseEntity<CommonResponse<TerritoryIdResponseDto>> addCategory(
+    public CommonResponse<TerritoryIdResponseDto> addCategory(
         @RequestBody @Validated TerritoryAddRequestDto requestBody) {
         //TODO: 마스터만 호출할 수 있도록 추가
         String territoryId = territoryService.addTerritory(requestBody.name());
-        return new ResponseEntity<>(
-            CommonResponse.success(new TerritoryIdResponseDto(territoryId)),
-            HttpStatus.CREATED);
+        return CommonResponse.success(new TerritoryIdResponseDto(territoryId));
     }
 
     /**

--- a/src/main/java/com/nameplz/baedal/domain/territory/repository/TerritoryRepository.java
+++ b/src/main/java/com/nameplz/baedal/domain/territory/repository/TerritoryRepository.java
@@ -10,4 +10,5 @@ public interface TerritoryRepository extends JpaRepository<Territory, UUID>,
 
     Optional<Territory> findByName(String name);
 
+    Optional<Territory> findByIdAndDeletedAtIsNull(UUID territoryId);
 }

--- a/src/main/java/com/nameplz/baedal/domain/territory/service/TerritoryService.java
+++ b/src/main/java/com/nameplz/baedal/domain/territory/service/TerritoryService.java
@@ -65,8 +65,8 @@ public class TerritoryService {
     }
 
     private Territory findTerritoryById(UUID territoryId) {
-        return territoryRepository.findById(territoryId)
-            .orElseThrow(() -> new GlobalException(ResultCase.NOT_FOUND));
+        return territoryRepository.findByIdAndDeletedAtIsNull(territoryId)
+            .orElseThrow(() -> new GlobalException(ResultCase.TERRITORY_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -48,7 +48,15 @@ public enum ResultCase {
 
     /* 리뷰 5000번대 */
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, 5000, "리뷰를 찾을 수 없습니다."),
-    ;
+
+    /* 가게 및 상품 5000 번대*/
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 5000, "가게 정보를 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "상품 정보를 찾을 수 없습니다."),
+
+    /* 카테고리 및 지역 6000 번대*/
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 6000, "카테고리 정보를 찾을 수 없습니다."),
+    TERRITORY_NOT_FOUND(HttpStatus.NOT_FOUND, 6001, "지역 정보를 찾을 수 없습니다.");
+
 
     private final HttpStatus httpStatus; // 응답 상태 코드
     private final Integer code; // 응답 코드. 도메인에 따라 1000번대로 나뉨


### PR DESCRIPTION
## 개요
- Category, territory, store, product의 통상 접근에서 delete된 객체 접근 제어

## 작업사항
- Category, territory, store, product, 삭제된 데이터 접근 제어
- 각 도메인마다 ResultCase 처리
- Category와 territory에 Response에 Created status OK 로 변경
