### PR TITLE
enhance: 활성화된 프로필을 prod로 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app/app.jar
 
 # 컨테이너 실행 시 JAR 파일 실행
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app/app.jar"]


### PR DESCRIPTION
## 개요
- CI/CD를 구현하고 있습니다.

## 작업사항
- CI는 성공했습니다.
- CD는 도커 허브에 이미지를 올리고, EC2에 실행하는 부분까지 성공했습니다.
- EC2에서 실행되는 스프링의 profile이 dev로 되어있어서 이를 prod로 Dockerfile을 바꾸었습니다. 

