### PR TITLE
feat: 테스트 커버리지를 위한 jacoco 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+/jacoco

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.name-plz'
@@ -90,4 +91,84 @@ clean {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport' // test 끝나면 jacocoTestReport 동작
+}
+
+// jacoco report 설정
+jacocoTestReport {
+    reports {
+        // 리포트 타입마다 리포트 저장 경로를 설정할 수 있습니다.
+        html.destination file("jacoco/report")
+    }
+
+    // QueryDsl Q class 제외
+    def Qdomains = []
+    for (qPattern in '**/QA'..'**/QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
+    // 커버리지 보고서 제외 범위 설정
+    getClassDirectories().setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: [
+                        "**/*Application*",
+                        "**/*Config*",
+                        "**/dto",
+                        "**/*Exception*"
+                ] + Qdomains)
+            })
+    )
+
+    // jacocoTestReport 끝나면 jacocoTestCoverageVerification 동작
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+// jacoco 커버리지 검증 설정
+jacocoTestCoverageVerification {
+
+    def Qdomains = []
+    for (qPattern in '*.QA'..'*.QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+        rule {
+            enabled = true // 커버리지 적용 여부
+            element = 'CLASS' // 커버리지 적용 단위
+
+            // 라인 커버리지 설정
+            // 적용 대상 전체 소스 코드들을 한줄 한줄 따졌을 때 테스트 코드가 작성되어 있는 줄의 빈도
+            // 테스트 코드가 작성되어 있는 비율이 60% 이상이어야 함
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+//                minimum = 0.60
+            }
+
+            // 브랜치 커버리지 설정
+            // if-else 등을 활용하여 발생되는 분기들 중 테스트 코드가 작성되어 있는 빈도
+            // 테스트 코드가 작성되어 있는 비율이 60% 이상이어야 함
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+//                minimum = 0.60
+            }
+
+            // 라인 최대 갯수 설정
+            // 빈 줄을 제외하고 하나의 자바 파일에서 작성될 수 있는 최대 라인 갯수
+            // 한 파일에 최대 500줄까지 작성되어야 함
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 500
+            }
+
+            excludes = [
+                    "**/*Application*",
+                    "**/*Config*",
+                    "**/dto",
+                    "**/*Exception*"
+            ] + Qdomains
+        }
+    }
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## 개요
- Jacoco를 추가했습니다. 

## 작업사항
- jacoco 플러그인 추가 
- 테스트 커버리지에서 중요하지 않은 파일들 제외 
- jacoco 결과로 나오는 report를 .gitignore에 추가 

## 추가사항
- gradle로 test 돌리시면 자동으로 jacoco로 테스트 커버리지 레포트가 만들어지도록 설정해뒀습니다.
- 프로젝트 루트 디렉토리에 jacoco/report/index.html 파일을 보시면 됩니다!

