### PR TITLE
feat: Swagger 설정 추가 

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/model/Address.java
+++ b/src/main/java/com/nameplz/baedal/domain/model/Address.java
@@ -1,5 +1,6 @@
 package com.nameplz.baedal.domain.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
@@ -12,11 +13,14 @@ import lombok.*;
 public class Address {
 
     @Column(name = "road_address")
+    @Schema(description = "도로명 주소", example = "서울특별시 강남구 테헤란로 427")
     private String roadAddress;
 
     @Column(name = "detail_address")
+    @Schema(description = "상세 주소", example = "와르르맨션 202호")
     private String detailAddress;
 
     @Column(name = "zipcode", length = 100)
+    @Schema(description = "우편번호", example = "06159")
     private String zipcode;
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
@@ -6,6 +6,7 @@ import com.nameplz.baedal.domain.order.dto.response.OrderResponseDto;
 import com.nameplz.baedal.domain.order.service.OrderService;
 import com.nameplz.baedal.global.common.response.CommonResponse;
 import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "주문")
 @RequestMapping("/orders")
 public class OrderController {
 

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderLineRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderLineRequestDto.java
@@ -1,10 +1,22 @@
 package com.nameplz.baedal.domain.order.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
 import java.util.UUID;
 
+@Schema(description = "주문목록 생성 요청")
 public record CreateOrderLineRequestDto(
+
+        @Schema(description = "메뉴 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID menuId,
+
+        @Schema(description = "수량", example = "2")
+        @NotNull(message = "수량은 필수입니다.")
         Integer quantity,
+
+        @Schema(description = "가격", example = "10000")
+        @NotNull(message = "가격은 필수입니다.")
         Integer price
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderRequestDto.java
@@ -2,16 +2,40 @@ package com.nameplz.baedal.domain.order.dto.request;
 
 import com.nameplz.baedal.domain.model.Address;
 import com.nameplz.baedal.domain.order.domain.OrderType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "주문 생성 요청")
 public record CreateOrderRequestDto(
+
+        @Schema(description = "주문자 (username)", example = "johndoe")
+        @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "주문자는 소문자 알파벳과 숫자로 4자 이상 10자 이하로 입력해주세요.")
         String orderer,
+
+        @Schema(description = "가게 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+        @NotNull(message = "가게 ID는 필수입니다.")
         UUID storeId,
+
+        @Schema(description = "주문 타입", example = "ONLINE")
         OrderType orderType,
+
+        @Schema(description = "주문 요청 사항", example = "2인분 같은 1인분으로 부탁드려요.")
         String comment,
+
+        @Schema(description = "주소 정보")
+        @NotNull(message = "주소 정보는 필수입니다.")
         Address address,
-        List<CreateOrderLineRequestDto> orderLineList
+
+        @Schema(description = "주문 상품 목록")
+        @Size(min = 1, message = "주문 상품은 최소 1개 이상이어야 합니다.")
+        List<CreateOrderLineRequestDto> orderLineList,
+
+        @Schema(description = "결제 정보")
+        PaymentRequestDto paymentInfo
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/PaymentRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/PaymentRequestDto.java
@@ -1,0 +1,18 @@
+package com.nameplz.baedal.domain.order.dto.request;
+
+import com.nameplz.baedal.domain.payment.domain.PaymentMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "주문 요청 시 포함되는 결제 정보")
+public record PaymentRequestDto(
+
+        @Schema(description = "결제 금액", example = "10000")
+        @NotNull(message = "결제 금액은 필수입니다.")
+        Integer amount,
+
+        @Schema(description = "결제 방식", example = "CARD")
+        @NotNull(message = "결제 방식은 필수입니다.")
+        PaymentMethod method
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/UpdateOrderStatusRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/UpdateOrderStatusRequestDto.java
@@ -1,8 +1,12 @@
 package com.nameplz.baedal.domain.order.dto.request;
 
 import com.nameplz.baedal.domain.order.domain.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "주문 상태 변경 요청")
 public record UpdateOrderStatusRequestDto(
+
+        @Schema(description = "주문 상태", example = "PAYMENT_WAITING")
         OrderStatus orderStatus
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderLineResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderLineResponseDto.java
@@ -1,14 +1,26 @@
 package com.nameplz.baedal.domain.order.dto.response;
 
 import com.nameplz.baedal.domain.model.Money;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.UUID;
 
+@Schema(description = "주문목록 응답")
 public record OrderLineResponseDto(
+
+        @Schema(description = "주문 목록 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID orderLineId,
+
+        @Schema(description = "주문 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID orderId,
+
+        @Schema(description = "상품 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID productId,
+
+        @Schema(description = "상품 수량", example = "2")
         Integer quantity,
+
+        @Schema(description = "가격", example = "10000")
         Money amount
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/response/OrderResponseDto.java
@@ -1,20 +1,42 @@
 package com.nameplz.baedal.domain.order.dto.response;
 
 import com.nameplz.baedal.domain.model.Address;
+import com.nameplz.baedal.domain.order.domain.OrderStatus;
+import com.nameplz.baedal.domain.order.domain.OrderType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "주문 응답")
 public record OrderResponseDto(
+
+        @Schema(description = "주문 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID orderId,
-        String orderStatus,
-        String orderType,
+
+        @Schema(description = "주문 상태", example = "PAYMENT_WAITING")
+        OrderStatus orderStatus,
+
+        @Schema(description = "주문 타입", example = "ONLINE")
+        OrderType orderType,
+
+        @Schema(description = "주문 요청 사항", example = "2인분 같은 1인분으로 부탁드려요.")
         String comment,
+
+        @Schema(description = "주소 정보")
         Address address,
+
+        @Schema(description = "주문자 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         String userId,
+
+        @Schema(description = "가게 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID storeId,
+
+        @Schema(description = "주문 상품 목록")
         List<OrderLineResponseDto> orderLineList,
+
+        @Schema(description = "주문 생성 일자", example = "2024-08-31T06:00:48.416Z")
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/mapper/OrderMapper.java
@@ -12,9 +12,13 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 @Mapper(componentModel = SPRING)
 public interface OrderMapper {
 
+    @Mapping(target = "productId", source = "product.id")
+    @Mapping(target = "orderId", source = "order.id")
     @Mapping(target = "orderLineId", source = "orderLine.id")
     OrderLineResponseDto toOrderLineResponseDto(OrderLine orderLine);
 
+    @Mapping(target = "storeId", source = "order.store.id")
+    @Mapping(target = "userId", source = "order.user.username")
     @Mapping(target = "orderId", source = "order.id")
     @Mapping(
             target = "orderLineList",

--- a/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthorizationFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,6 +15,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
 
 @Slf4j(topic = "JWT 검증 및 인가")
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     // 로그인을 제외한 요청마다 필터실행. jwt에 담긴 정보를 추출해 authentication 객체에 저장
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
-        FilterChain filterChain) throws ServletException, IOException {
+                                    FilterChain filterChain) throws ServletException, IOException {
 
         String tokenValue = jwtUtil.getTokenFromRequest(req);
 
@@ -68,6 +69,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private Authentication createAuthentication(String username) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         return new UsernamePasswordAuthenticationToken(userDetails, null,
-            userDetails.getAuthorities());
+                userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/nameplz/baedal/global/common/jwt/JwtUtil.java
+++ b/src/main/java/com/nameplz/baedal/global/common/jwt/JwtUtil.java
@@ -1,28 +1,23 @@
 package com.nameplz.baedal.global.common.jwt;
 
 import com.nameplz.baedal.domain.user.domain.UserRole;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * jwt 관련 기능들을 가진 클래스, jwt Util 만드는 중 (특정 파라미터에 대한 작업을 수행하는 메소드들이 있는 곳) (다른 객체에 의존하지 않고 하나의 모듈로써
@@ -61,13 +56,13 @@ public class JwtUtil {
         Date date = new Date();
 
         return BEARER_PREFIX +
-            Jwts.builder()
-                .subject(username) // 사용자 식별자값(ID)
-                .claim(AUTHORIZATION_KEY, role) // 사용자 권한
-                .expiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
-                .issuedAt(date) // 발급일
-                .signWith(key) // 암호화 알고리즘
-                .compact();
+               Jwts.builder()
+                       .subject(username) // 사용자 식별자값(ID)
+                       .claim(AUTHORIZATION_KEY, role) // 사용자 권한
+                       .expiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+                       .issuedAt(date) // 발급일
+                       .signWith(key) // 암호화 알고리즘
+                       .compact();
     }
 
     // 2. jWT를 쿠키에 저장
@@ -75,7 +70,7 @@ public class JwtUtil {
         try {
             // TODO : utf-8을 하드코딩 하기보다 StandardCharsets.UTF_8.name() 를 사용하면 좋을 것 같습니다!
             token = URLEncoder.encode(token, "utf-8")
-                .replaceAll("\\+", "%20"); // Cookie Value 에는 공백이 불가능해서 encoding 진행
+                    .replaceAll("\\+", "%20"); // Cookie Value 에는 공백이 불가능해서 encoding 진행
 
             Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token); // Name-Value
             cookie.setPath("/");
@@ -131,7 +126,7 @@ public class JwtUtil {
                 if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
                     try {
                         return URLDecoder.decode(cookie.getValue(),
-                            "UTF-8"); // Encode 되어 넘어간 Value 다시 Decode
+                                "UTF-8"); // Encode 되어 넘어간 Value 다시 Decode
                     } catch (UnsupportedEncodingException e) {
                         return null;
                     }

--- a/src/main/java/com/nameplz/baedal/global/common/response/CommonResponse.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/CommonResponse.java
@@ -1,5 +1,6 @@
 package com.nameplz.baedal.global.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,11 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class CommonResponse<T> implements Serializable {
 
+    @Schema(description = "응답 코드", example = "0")
     private Integer code; // 커스텀 응답 코드
+    @Schema(description = "응답 메시지", example = "정상 처리 되었습니다.")
     private String message; // 응답에 대한 설명
+    @Schema(description = "응답 데이터", example = "{}")
     private T data; // 응답에 필요한 데이터
 
     /**

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ResultCase {
 
     /* 성공 0번대 - 모든 성공 응답을 200으로 통일 */
-    SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다"),
+    SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다."),
 
     /* 글로벌 1000번대 */
 

--- a/src/main/java/com/nameplz/baedal/global/config/SwaggerConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/SwaggerConfig.java
@@ -1,10 +1,19 @@
 package com.nameplz.baedal.global.config;
 
+import com.nameplz.baedal.global.common.jwt.JwtUtil;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 @Configuration
 public class SwaggerConfig {
@@ -12,9 +21,42 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
 
+        Components components = new Components();
+
+        addPageableSchemas(components); // Pageable 스키마 추가
+        addSecuritySchemes(components); // 인증 스키마 추가
+
+        SecurityRequirement accessTokenRequirement = new SecurityRequirement().addList(JwtUtil.AUTHORIZATION_HEADER);
+
         return new OpenAPI()
                 .info(info())
-                .components(new Components());
+                .components(components)
+                .addSecurityItem(accessTokenRequirement);
+    }
+
+    private void addPageableSchemas(Components components) {
+
+        Schema<?> properties = new MapSchema()
+                .properties(Map.of(
+                        "page", new IntegerSchema().example(1),
+                        "size", new IntegerSchema().example(10),
+                        "sort", new StringSchema().example("createdAt,desc")
+                ));
+
+        components.addSchemas("Pageable", properties);
+    }
+
+    private void addSecuritySchemes(Components components) {
+        components.addSecuritySchemes(JwtUtil.AUTHORIZATION_HEADER, accessTokenSecurityScheme());
+    }
+
+    private SecurityScheme accessTokenSecurityScheme() {
+        return new SecurityScheme()
+                .name(JwtUtil.AUTHORIZATION_HEADER) // Authorization 을 키로 함
+                .type(SecurityScheme.Type.APIKEY) // name 값을 키로 함. (HTTP 설정 시 Authorization 고정이지만 확장 차)
+                .in(SecurityScheme.In.COOKIE) // 액세스 토큰은 헤더에 속함
+                .scheme(JwtUtil.BEARER_PREFIX) // Bearer 접두사 붙음
+                .bearerFormat("JWT"); // 유형은 JWT
     }
 
     private Info info() {

--- a/src/main/java/com/nameplz/baedal/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/WebSecurityConfig.java
@@ -5,7 +5,6 @@ import com.nameplz.baedal.global.common.jwt.JwtAuthenticationFilter;
 import com.nameplz.baedal.global.common.jwt.JwtAuthorizationFilter;
 import com.nameplz.baedal.global.common.jwt.JwtUtil;
 import com.nameplz.baedal.global.common.security.UserDetailsServiceImpl;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +25,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true) // 컨트롤러에서 Secured 어노테이션 사용위한 어노테이션
@@ -33,15 +34,15 @@ import org.springframework.web.cors.CorsConfiguration;
 public class WebSecurityConfig {
 
     private static final List<String> ALLOWED_ORIGINS = List.of(
-        "http://localhost:3000"
+            "http://localhost:3000"
     );
     private static final List<String> ALLOWED_METHODS = List.of(
-        HttpMethod.GET.name(),
-        HttpMethod.POST.name(),
-        HttpMethod.PUT.name(),
-        HttpMethod.PATCH.name(),
-        HttpMethod.DELETE.name(),
-        HttpMethod.OPTIONS.name()
+            HttpMethod.GET.name(),
+            HttpMethod.POST.name(),
+            HttpMethod.PUT.name(),
+            HttpMethod.PATCH.name(),
+            HttpMethod.DELETE.name(),
+            HttpMethod.OPTIONS.name()
     );
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
@@ -49,7 +50,7 @@ public class WebSecurityConfig {
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
-        throws Exception {
+            throws Exception {
         return configuration.getAuthenticationManager();
     }
 
@@ -84,7 +85,7 @@ public class WebSecurityConfig {
 
         // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
         http.sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(
-            SessionCreationPolicy.STATELESS));
+                SessionCreationPolicy.STATELESS));
 
         // 요청 URL 접근 설정
         settingRequestAuthorization(http);
@@ -93,7 +94,7 @@ public class WebSecurityConfig {
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(new AuthenticationLoggingFilter(),
-            UsernamePasswordAuthenticationFilter.class); // 유저 권한 로깅을 위한 필터
+                UsernamePasswordAuthenticationFilter.class); // 유저 권한 로깅을 위한 필터
 
         return http.build();
     }
@@ -117,11 +118,12 @@ public class WebSecurityConfig {
      */
     private void settingRequestAuthorization(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(authz ->
-            authz
-                // 정적 파일
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                // 그 외
-                .anyRequest().permitAll() // TODO : 인증 구현 후 authenticated()로 변경
+                authz
+                        // 정적 파일
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        // 그 외
+                        .anyRequest().permitAll() // TODO : 인증 구현 후 authenticated()로 변경
         );
     }
 }

--- a/src/main/java/com/nameplz/baedal/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/WebSecurityConfig.java
@@ -122,7 +122,7 @@ public class WebSecurityConfig {
                 // 정적 파일
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 // Swagger UI
-                .requestMatcher("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/users/**").permitAll()
                 .requestMatchers("/admin/login").permitAll()
                 // 그 외

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,3 +19,7 @@ spring:
         format_sql: true # SQL 문 정렬하여 출력
         highlight_sql: true # SQL 문 색 부여
         use_sql_comments: true # 콘솔에 표시되는 쿼리문 위에 어떤 실행을 하려는지 HINT 표시
+
+jwt:
+  secret:
+    key: 7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==


### PR DESCRIPTION
## 개요
- Swagger 설정을 추가했습니다. 

## 작업사항
- Swagger UI 접근 허용 
- Swagger 내에서 Authorization 기능 추가 
  - 하지만 UI에서 쿠키 인증을 지원하지 않아서 활용은 못합니다.
  - 개발자 도구 내의 쿠키로 설정해두면 편히 할 수 있습니다.
- Order 도메인 한정 DTO에 스웨거 예시 설정 
- Pageable 입력을 받는 API에 예시 개선
  - 기존에는 sort 부분이 배열이 되어 있었지만, 이를 "createdAt,desc"로 개선.
- test 디렉토리 내의 application.yml 파일에 JWT 시크릿키 추가 

## 관련 이슈
- 
