### PR TITLE
feat: 결제 도메인 인가 처리 

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
@@ -10,6 +10,8 @@ import com.nameplz.baedal.global.common.response.EmptyResponseDto;
 import com.nameplz.baedal.global.common.security.annotation.IsMaster;
 import com.nameplz.baedal.global.common.security.annotation.IsMasterOrSelf;
 import com.nameplz.baedal.global.common.security.annotation.LoginUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "결제")
 @RequestMapping("/payments")
 public class PaymentController {
 
@@ -33,6 +36,8 @@ public class PaymentController {
      * 결제 조회
      */
     @GetMapping("/{paymentId}")
+    @IsMaster
+    @Operation(summary = "결제 조회")
     public CommonResponse<PaymentResponseDto> getPayment(@PathVariable UUID paymentId) {
 
         PaymentResponseDto response = paymentService.getPayment(paymentId);
@@ -45,6 +50,7 @@ public class PaymentController {
      */
     @GetMapping
     @IsMasterOrSelf
+    @Operation(summary = "결제 리스트 조회")
     public CommonResponse<List<PaymentResponseDto>> getPaymentList(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @LoginUser User user
@@ -56,10 +62,11 @@ public class PaymentController {
     }
 
     /**
-     * 결제 생성
+     * 결제 처리
      */
     @PostMapping
     @IsMaster
+    @Operation(summary = "결제 처리")
     public CommonResponse<PaymentResponseDto> createPayment(@Valid @RequestBody CreatePaymentRequestDto request) {
 
         PaymentResponseDto response = paymentService.createPayment(request);
@@ -72,6 +79,7 @@ public class PaymentController {
      */
     @PatchMapping("/{paymentId}/status")
     @IsMaster
+    @Operation(summary = "결제 상태 변경")
     public CommonResponse<EmptyResponseDto> updatePaymentStatus(
             @PathVariable UUID paymentId,
             @RequestBody ChangePaymentStatusRequestDto request,
@@ -88,6 +96,7 @@ public class PaymentController {
      */
     @DeleteMapping("/{paymentId}")
     @IsMaster
+    @Operation(summary = "결제 삭제")
     public CommonResponse<EmptyResponseDto> deletePayment(
             @PathVariable UUID paymentId,
             @LoginUser User user

--- a/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
@@ -4,8 +4,12 @@ import com.nameplz.baedal.domain.payment.dto.request.ChangePaymentStatusRequestD
 import com.nameplz.baedal.domain.payment.dto.request.CreatePaymentRequestDto;
 import com.nameplz.baedal.domain.payment.dto.response.PaymentResponseDto;
 import com.nameplz.baedal.domain.payment.service.PaymentService;
+import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.global.common.response.CommonResponse;
 import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import com.nameplz.baedal.global.common.security.annotation.IsMaster;
+import com.nameplz.baedal.global.common.security.annotation.IsMasterOrSelf;
+import com.nameplz.baedal.global.common.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,11 +44,13 @@ public class PaymentController {
      * 결제 리스트 조회
      */
     @GetMapping
+    @IsMasterOrSelf
     public CommonResponse<List<PaymentResponseDto>> getPaymentList(
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @LoginUser User user
     ) {
 
-        List<PaymentResponseDto> response = paymentService.getPaymentList(pageable);
+        List<PaymentResponseDto> response = paymentService.getPaymentList(pageable, user);
 
         return CommonResponse.success(response);
     }
@@ -53,6 +59,7 @@ public class PaymentController {
      * 결제 생성
      */
     @PostMapping
+    @IsMaster
     public CommonResponse<PaymentResponseDto> createPayment(@Valid @RequestBody CreatePaymentRequestDto request) {
 
         PaymentResponseDto response = paymentService.createPayment(request);
@@ -64,12 +71,14 @@ public class PaymentController {
      * 결제 상태 변경
      */
     @PatchMapping("/{paymentId}/status")
+    @IsMaster
     public CommonResponse<EmptyResponseDto> updatePaymentStatus(
             @PathVariable UUID paymentId,
-            @RequestBody ChangePaymentStatusRequestDto request
+            @RequestBody ChangePaymentStatusRequestDto request,
+            @LoginUser User user
     ) {
 
-        paymentService.changePaymentStatus(paymentId, request);
+        paymentService.changePaymentStatus(paymentId, request, user);
 
         return CommonResponse.success();
     }
@@ -78,9 +87,13 @@ public class PaymentController {
      * 결제 삭제
      */
     @DeleteMapping("/{paymentId}")
-    public CommonResponse<EmptyResponseDto> deletePayment(@PathVariable UUID paymentId) {
+    @IsMaster
+    public CommonResponse<EmptyResponseDto> deletePayment(
+            @PathVariable UUID paymentId,
+            @LoginUser User user
+    ) {
 
-        paymentService.deletePayment(paymentId);
+        paymentService.deletePayment(paymentId, user);
 
         return CommonResponse.success();
     }

--- a/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
@@ -8,7 +8,6 @@ import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.global.common.response.CommonResponse;
 import com.nameplz.baedal.global.common.response.EmptyResponseDto;
 import com.nameplz.baedal.global.common.security.annotation.IsMaster;
-import com.nameplz.baedal.global.common.security.annotation.IsMasterOrSelf;
 import com.nameplz.baedal.global.common.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +25,7 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@IsMaster
 @Tag(name = "결제")
 @RequestMapping("/payments")
 public class PaymentController {
@@ -36,7 +36,6 @@ public class PaymentController {
      * 결제 조회
      */
     @GetMapping("/{paymentId}")
-    @IsMaster
     @Operation(summary = "결제 조회")
     public CommonResponse<PaymentResponseDto> getPayment(@PathVariable UUID paymentId) {
 
@@ -49,7 +48,6 @@ public class PaymentController {
      * 결제 리스트 조회
      */
     @GetMapping
-    @IsMasterOrSelf
     @Operation(summary = "결제 리스트 조회")
     public CommonResponse<List<PaymentResponseDto>> getPaymentList(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -64,7 +62,6 @@ public class PaymentController {
      * 결제 처리
      */
     @PostMapping
-    @IsMaster
     @Operation(summary = "결제 처리")
     public CommonResponse<PaymentResponseDto> createPayment(@Valid @RequestBody CreatePaymentRequestDto request) {
 
@@ -77,7 +74,6 @@ public class PaymentController {
      * 결제 상태 변경
      */
     @PatchMapping("/{paymentId}/status")
-    @IsMaster
     @Operation(summary = "결제 상태 변경")
     public CommonResponse<EmptyResponseDto> updatePaymentStatus(
             @PathVariable UUID paymentId,
@@ -94,7 +90,6 @@ public class PaymentController {
      * 결제 삭제
      */
     @DeleteMapping("/{paymentId}")
-    @IsMaster
     @Operation(summary = "결제 삭제")
     public CommonResponse<EmptyResponseDto> deletePayment(
             @PathVariable UUID paymentId,

--- a/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/controller/PaymentController.java
@@ -52,11 +52,10 @@ public class PaymentController {
     @IsMasterOrSelf
     @Operation(summary = "결제 리스트 조회")
     public CommonResponse<List<PaymentResponseDto>> getPaymentList(
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-            @LoginUser User user
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
 
-        List<PaymentResponseDto> response = paymentService.getPaymentList(pageable, user);
+        List<PaymentResponseDto> response = paymentService.getPaymentList(pageable);
 
         return CommonResponse.success(response);
     }

--- a/src/main/java/com/nameplz/baedal/domain/payment/domain/Payment.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/domain/Payment.java
@@ -35,17 +35,21 @@ public class Payment extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 
+    @Column(name = "username")
+    private String username;
+
     /**
      * 외부 결제 모듈의 결과를 저장
      */
-    public static Payment create(Money amount, String paymentKey, PaymentMethod method, PaymentStatus status) {
+    public static Payment create(Money amount, PaymentMethod method, String username) {
 
         Payment payment = new Payment();
 
         payment.amount = amount;
-        payment.paymentKey = paymentKey;
         payment.method = method;
-        payment.status = status;
+        payment.username = username;
+        payment.status = PaymentStatus.PENDING;
+        payment.createdUser = username;
 
         return payment;
     }

--- a/src/main/java/com/nameplz/baedal/domain/payment/domain/Payment.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/domain/Payment.java
@@ -54,8 +54,9 @@ public class Payment extends BaseEntity {
         return payment;
     }
 
-    public void success() {
+    public void success(String paymentKey) {
         this.status = PaymentStatus.SUCCESS;
+        this.paymentKey = paymentKey;
     }
 
     public void fail() {

--- a/src/main/java/com/nameplz/baedal/domain/payment/domain/Payment.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/domain/Payment.java
@@ -54,7 +54,16 @@ public class Payment extends BaseEntity {
         return payment;
     }
 
-    public void changePaymentStatus(PaymentStatus status) {
+    public void success() {
+        this.status = PaymentStatus.SUCCESS;
+    }
+
+    public void fail() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    public void changePaymentStatus(PaymentStatus status, String username) {
         this.status = status;
+        this.updatedUser = username;
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/domain/PaymentStatus.java
@@ -2,5 +2,7 @@ package com.nameplz.baedal.domain.payment.domain;
 
 public enum PaymentStatus {
     SUCCESS,
-    CANCELED
+    CANCELED,
+    FAILED,
+    PENDING
 }

--- a/src/main/java/com/nameplz/baedal/domain/payment/dto/request/ChangePaymentStatusRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/dto/request/ChangePaymentStatusRequestDto.java
@@ -1,8 +1,11 @@
 package com.nameplz.baedal.domain.payment.dto.request;
 
 import com.nameplz.baedal.domain.payment.domain.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ChangePaymentStatusRequestDto(
+
+        @Schema(description = "결제 상태", example = "SUCCESS")
         PaymentStatus status
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/payment/dto/request/CreatePaymentRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/dto/request/CreatePaymentRequestDto.java
@@ -1,12 +1,22 @@
 package com.nameplz.baedal.domain.payment.dto.request;
 
 import com.nameplz.baedal.domain.payment.domain.PaymentMethod;
-import com.nameplz.baedal.domain.payment.domain.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
 
 public record CreatePaymentRequestDto(
+
+        @Schema(description = "결제 금액", example = "10000")
+        @Range(message = "금액은 0 이상이어야 합니다.")
+        @NotNull(message = "금액은 필수입니다.")
         Integer amount,
-        String paymentKey,
+
+        @Schema(description = "결제 방식", example = "CARD")
         PaymentMethod method,
-        PaymentStatus status
+
+        @Schema(description = "결제자", example = "johndoe")
+        @NotNull(message = "결제자는 필수입니다.")
+        String username
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/payment/dto/response/PaymentResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/dto/response/PaymentResponseDto.java
@@ -2,13 +2,25 @@ package com.nameplz.baedal.domain.payment.dto.response;
 
 import com.nameplz.baedal.domain.payment.domain.PaymentMethod;
 import com.nameplz.baedal.domain.payment.domain.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.UUID;
 
 public record PaymentResponseDto(
+
+        @Schema(description = "결제 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID paymentId,
+
+        @Schema(description = "결제자", example = "johndoe")
+        String username,
+
+        @Schema(description = "결제 금액", example = "10000")
         Integer amount,
+
+        @Schema(description = "결제 방식", example = "CARD")
         PaymentMethod method,
+
+        @Schema(description = "결제 상태", example = "SUCCESS")
         PaymentStatus status
 ) {
 }

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
@@ -52,7 +52,11 @@ public class PaymentService {
     @Transactional
     public PaymentResponseDto createPayment(CreatePaymentRequestDto request) {
 
-        Payment payment = Payment.create(new Money(request.amount()), request.paymentKey(), request.method(), request.status());
+        Payment payment = Payment.create(new Money(request.amount()), request.method(), request.username());
+
+        // 외부 결제 모듈에 결제 요청
+
+        payment.success();
         Payment savedPayment = paymentRepository.save(payment);
 
         return mapper.toPaymentResponseDto(savedPayment);

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
@@ -7,6 +7,7 @@ import com.nameplz.baedal.domain.payment.dto.request.CreatePaymentRequestDto;
 import com.nameplz.baedal.domain.payment.dto.response.PaymentResponseDto;
 import com.nameplz.baedal.domain.payment.mapper.PaymentMapper;
 import com.nameplz.baedal.domain.payment.repository.PaymentRepository;
+import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.global.common.exception.GlobalException;
 import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.RequiredArgsConstructor;
@@ -66,19 +67,18 @@ public class PaymentService {
      * 결제 상태 변경
      */
     @Transactional
-    public void changePaymentStatus(UUID paymentId, ChangePaymentStatusRequestDto request) {
+    public void changePaymentStatus(UUID paymentId, ChangePaymentStatusRequestDto request, User user) {
         Payment payment = findPayment(paymentId);
-        payment.changePaymentStatus(request.status());
+        payment.changePaymentStatus(request.status(), user.getUsername());
     }
 
     /**
      * 결제 삭제
      */
     @Transactional
-    public void deletePayment(UUID paymentId) {
+    public void deletePayment(UUID paymentId, User user) {
         Payment payment = findPayment(paymentId);
-        // TODO : 삭제한 사용자 정보를 넘겨줘야함
-        payment.deleteEntity(null);
+        payment.deleteEntity(user.getUsername());
     }
 
     private Payment findPayment(UUID paymentId) {

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
@@ -59,8 +59,9 @@ public class PaymentService {
         Payment payment = Payment.create(new Money(request.amount()), request.method(), request.username());
 
         // 외부 결제 모듈에 결제 요청
+        String paymentKey = UUID.randomUUID().toString();
 
-        payment.success();
+        payment.success(paymentKey);
         Payment savedPayment = paymentRepository.save(payment);
 
         return mapper.toPaymentResponseDto(savedPayment);

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
@@ -13,7 +13,6 @@ import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,8 +40,7 @@ public class PaymentService {
      * 결제 리스트 조회
      * 마스터 권한이 있거나 응답 리스트의 각 요소의 username이 현재 사용자의 username과 일치하는 요소만 포함
      */
-    @PostFilter("hasRole('ROLE_MASTER') or filterObject.username == #user.username")
-    public List<PaymentResponseDto> getPaymentList(Pageable pageable, User user) {
+    public List<PaymentResponseDto> getPaymentList(Pageable pageable) {
 
         return paymentRepository.findAllByDeletedAtIsNull(pageable)
                 .stream()

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
@@ -13,6 +13,7 @@ import com.nameplz.baedal.global.common.response.ResultCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,8 +39,10 @@ public class PaymentService {
 
     /**
      * 결제 리스트 조회
+     * 마스터 권한이 있거나 응답 리스트의 각 요소의 username이 현재 사용자의 username과 일치하는 요소만 포함
      */
-    public List<PaymentResponseDto> getPaymentList(Pageable pageable) {
+    @PostFilter("hasRole('ROLE_MASTER') or filterObject.username == #user.username")
+    public List<PaymentResponseDto> getPaymentList(Pageable pageable, User user) {
 
         return paymentRepository.findAllByDeletedAtIsNull(pageable)
                 .stream()

--- a/src/main/java/com/nameplz/baedal/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/nameplz/baedal/domain/review/mapper/ReviewMapper.java
@@ -13,5 +13,6 @@ public interface ReviewMapper {
     @Mapping(target = "orderId", source = "order.id")
     @Mapping(target = "rating", source = "rating.score")
     @Mapping(target = "username", source = "user.username")
+    @Mapping(target = "isReported", source = "reported")
     ReviewResponseDto toReviewResponseDto(Review review);
 }

--- a/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMaster.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMaster.java
@@ -1,0 +1,16 @@
+package com.nameplz.baedal.global.common.security.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.nameplz.baedal.domain.user.domain.UserRole.Authority.MASTER;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and hasRole('" + MASTER + "')")
+public @interface IsMaster {
+}

--- a/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMasterOrCustomer.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMasterOrCustomer.java
@@ -1,0 +1,17 @@
+package com.nameplz.baedal.global.common.security.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.nameplz.baedal.domain.user.domain.UserRole.Authority.CUSTOMER;
+import static com.nameplz.baedal.domain.user.domain.UserRole.Authority.MASTER;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and ( hasRole('" + MASTER + "') or hasRole('" + CUSTOMER + "') )")
+public @interface IsMasterOrCustomer {
+}

--- a/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMasterOrOwner.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMasterOrOwner.java
@@ -1,0 +1,17 @@
+package com.nameplz.baedal.global.common.security.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.nameplz.baedal.domain.user.domain.UserRole.Authority.MASTER;
+import static com.nameplz.baedal.domain.user.domain.UserRole.Authority.OWNER;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and ( hasRole('" + OWNER + "') or hasRole('" + MASTER + "') )")
+public @interface IsMasterOrOwner {
+}

--- a/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMasterOrSelf.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/annotation/IsMasterOrSelf.java
@@ -1,0 +1,24 @@
+package com.nameplz.baedal.global.common.security.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.nameplz.baedal.domain.user.domain.UserRole.Authority.MASTER;
+
+/**
+ * 권한이 Master 이거나, 유저 본인일 경우 허용
+ * 매개변수 속 username 이나 user.username 이 principal.username 과 같은지 확인
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and ( " +
+              "hasRole('" + MASTER + "') " +
+              "or #username == principal.username " +
+              "or #user.username == principal.username " +
+              ")")
+public @interface IsMasterOrSelf {
+}

--- a/src/main/java/com/nameplz/baedal/global/common/security/annotation/LoginUser.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/annotation/LoginUser.java
@@ -1,0 +1,18 @@
+package com.nameplz.baedal.global.common.security.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 인증 객체 정보를 가지고 다니는 커스텀 어노테이션.
+ * 익명(비로그인)이 아니라면 UserDetailsImpl 안의 User 객체를 가져옴.
+ */
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface LoginUser {
+}

--- a/src/main/java/com/nameplz/baedal/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/WebSecurityConfig.java
@@ -118,15 +118,15 @@ public class WebSecurityConfig {
      */
     private void settingRequestAuthorization(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(authz ->
-            authz
-                // 정적 파일
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                // Swagger UI
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers("/users/**").permitAll()
-                .requestMatchers("/admin/login").permitAll()
-                // 그 외
-                .anyRequest().authenticated() // TODO : 인증 구현 후 authenticated()로 변경
+                authz
+                        // 정적 파일
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        // Swagger UI
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/users/**").permitAll()
+                        .requestMatchers("/admin/login").permitAll()
+                        // 그 외
+                        .anyRequest().authenticated() // TODO : 인증 구현 후 authenticated()로 변경
         );
     }
 }


### PR DESCRIPTION
## 개요
- 결제 도메인 인가 처리했습니다. 

## 작업사항
- 인가 처리를 위한 편의 어노테이션 추가
  - `UserDetails` 에서 바로 `User`를 가져오는 `@LoginUser` 어노테이션 추가 
  - `Master` 또는 본인, 가게주인, 고객인지 확인하는 `@IsMaster-` 어노테이션 추가 
- 결제 도메인의 인가 처리
- 결제 로직 일부 수정
  - 결제 전에 모르는 정보를 요청 DTO에서 제외
  - 결제 처리 로직 중 외부 결제 모듈에 요청 보냈다고 가정하고 처리 
- Swagger 정보 추가 
- ReviewMapper의 boolean 타입 처리 로직 수정 

## 관련 이슈
- 
