### PR TITLE
feat: 주문 로직 고도화 

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
@@ -4,15 +4,17 @@ import com.nameplz.baedal.domain.order.dto.request.CreateOrderRequestDto;
 import com.nameplz.baedal.domain.order.dto.request.UpdateOrderStatusRequestDto;
 import com.nameplz.baedal.domain.order.dto.response.OrderResponseDto;
 import com.nameplz.baedal.domain.order.service.OrderService;
+import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.global.common.response.CommonResponse;
 import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import com.nameplz.baedal.global.common.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -69,8 +71,11 @@ public class OrderController {
      * 주문 생성
      */
     @PostMapping
-    public CommonResponse<OrderResponseDto> getOrderList(@Valid @RequestBody CreateOrderRequestDto request) {
-        OrderResponseDto response = orderService.createOrder(request);
+    public CommonResponse<OrderResponseDto> createOrder(
+            @Validated @RequestBody CreateOrderRequestDto request,
+            @LoginUser User user
+    ) {
+        OrderResponseDto response = orderService.createOrder(request, user);
 
         return CommonResponse.success(response);
     }

--- a/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/controller/OrderController.java
@@ -7,6 +7,9 @@ import com.nameplz.baedal.domain.order.service.OrderService;
 import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.global.common.response.CommonResponse;
 import com.nameplz.baedal.global.common.response.EmptyResponseDto;
+import com.nameplz.baedal.global.common.security.annotation.IsMaster;
+import com.nameplz.baedal.global.common.security.annotation.IsMasterOrOwner;
+import com.nameplz.baedal.global.common.security.annotation.IsMasterOrSelf;
 import com.nameplz.baedal.global.common.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +36,11 @@ public class OrderController {
      * 주문 단건 조회
      */
     @GetMapping("/{orderId}")
-    public CommonResponse<OrderResponseDto> getOrder(@PathVariable(name = "orderId") UUID orderId) {
-        OrderResponseDto response = orderService.getOrder(orderId);
+    public CommonResponse<OrderResponseDto> getOrder(
+            @PathVariable(name = "orderId") UUID orderId,
+            @LoginUser User user
+    ) {
+        OrderResponseDto response = orderService.getOrder(orderId, user);
 
         return CommonResponse.success(response);
     }
@@ -44,11 +50,12 @@ public class OrderController {
      * Pageable 예시 : ?page=0&size=10&sort=createdAt,desc
      */
     @GetMapping("/users/{userId}")
+    @IsMasterOrSelf
     public CommonResponse<List<OrderResponseDto>> getOrderListByUsername(
-            @PathVariable(name = "userId") String userId,
+            @PathVariable(name = "userId") String username,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<OrderResponseDto> response = orderService.getOrderListByUsername(userId, pageable);
+        List<OrderResponseDto> response = orderService.getOrderListByUsername(username, pageable);
 
         return CommonResponse.success(response);
     }
@@ -58,11 +65,13 @@ public class OrderController {
      * Pageable 예시 : ?page=0&size=10&sort=createdAt,desc
      */
     @GetMapping("/stores/{storeId}")
+    @IsMasterOrOwner // 서비스 내부에서 유저가 가게 주인 본인인지 확인함
     public CommonResponse<List<OrderResponseDto>> getOrderListByStoreId(
             @PathVariable(name = "storeId") UUID storeId,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @LoginUser User user
     ) {
-        List<OrderResponseDto> response = orderService.getOrderListByStoreId(storeId, pageable);
+        List<OrderResponseDto> response = orderService.getOrderListByStoreId(storeId, pageable, user);
 
         return CommonResponse.success(response);
     }
@@ -71,6 +80,7 @@ public class OrderController {
      * 주문 생성
      */
     @PostMapping
+    @IsMasterOrSelf
     public CommonResponse<OrderResponseDto> createOrder(
             @Validated @RequestBody CreateOrderRequestDto request,
             @LoginUser User user
@@ -84,6 +94,7 @@ public class OrderController {
      * 주문 상태 변경
      */
     @PatchMapping("/{orderId}/status")
+    @IsMaster
     public CommonResponse<EmptyResponseDto> updateOrderStatus(
             @PathVariable UUID orderId,
             @RequestBody UpdateOrderStatusRequestDto request
@@ -97,6 +108,7 @@ public class OrderController {
      * 주문 취소
      */
     @DeleteMapping("/{orderId}")
+    @IsMasterOrSelf
     public CommonResponse<EmptyResponseDto> cancelOrder(@PathVariable UUID orderId) {
         orderService.cancelOrder(orderId);
 

--- a/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/domain/Order.java
@@ -98,7 +98,6 @@ public class Order extends BaseEntity {
      * 주문 상태 변경 - 가게주인과 관리자만 가능
      */
     public void updateOrderStatus(OrderStatus orderStatus) {
-        // TODO : 권환 확인 필요
         this.orderStatus = orderStatus;
     }
 

--- a/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderLineRequestDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/dto/request/CreateOrderLineRequestDto.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 @Schema(description = "주문목록 생성 요청")
 public record CreateOrderLineRequestDto(
 
-        @Schema(description = "메뉴 ID", example = "123e4567-e89b-12d3-a456-426614174000")
-        UUID menuId,
+        @Schema(description = "상품 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+        UUID productId,
 
         @Schema(description = "수량", example = "2")
         @NotNull(message = "수량은 필수입니다.")

--- a/src/main/java/com/nameplz/baedal/domain/order/service/OrderProcessService.java
+++ b/src/main/java/com/nameplz/baedal/domain/order/service/OrderProcessService.java
@@ -1,0 +1,98 @@
+package com.nameplz.baedal.domain.order.service;
+
+import com.nameplz.baedal.domain.model.Money;
+import com.nameplz.baedal.domain.order.domain.Order;
+import com.nameplz.baedal.domain.order.domain.OrderLine;
+import com.nameplz.baedal.domain.order.domain.OrderStatus;
+import com.nameplz.baedal.domain.order.dto.request.CreateOrderLineRequestDto;
+import com.nameplz.baedal.domain.order.dto.request.CreateOrderRequestDto;
+import com.nameplz.baedal.domain.order.dto.request.PaymentRequestDto;
+import com.nameplz.baedal.domain.payment.domain.PaymentStatus;
+import com.nameplz.baedal.domain.payment.dto.request.CreatePaymentRequestDto;
+import com.nameplz.baedal.domain.payment.dto.response.PaymentResponseDto;
+import com.nameplz.baedal.domain.payment.service.PaymentService;
+import com.nameplz.baedal.domain.store.domain.Store;
+import com.nameplz.baedal.domain.user.domain.User;
+import com.nameplz.baedal.global.common.exception.GlobalException;
+import com.nameplz.baedal.global.common.response.ResultCase;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 주문을 처리하는 도메인 서비스
+ * 도메인 서비스 : 도메인 영역에서 한 애그리거트에 넣기 복잡한 로직을 다루거나, 여러 애그리거트가 필요한 경우 사용
+ * 또는 외부 서비스를 호출하는 로직을 처리할 때 사용 (이때는 인터페이스로 분리하여 구현체를 infra 패키지에 위치)
+ */
+@Service
+public class OrderProcessService {
+
+    public Order process(CreateOrderRequestDto requestDto, User user, Store store, PaymentService paymentService) {
+
+        // 가게와 주문한 상품 리스트 가져오기
+        List<UUID> productIdList = getOrderedProductIdList(requestDto);
+
+        // 주문한 상품의 id가 가게에서 판매하는 상품인지 확인
+        validateProductList(store, productIdList);
+
+        // 결제 요청
+        PaymentResponseDto paymentResponse = paymentService.createPayment(getCreatePaymentRequestDto(requestDto, user));
+
+        // 결제 여부 검증
+        validatePaymentResult(paymentResponse);
+
+        // 주문 생성
+        Order order = createOrderEntity(requestDto, user, store);
+        addOrderLineListInOrder(requestDto, order);
+
+        return order;
+    }
+
+    private List<UUID> getOrderedProductIdList(CreateOrderRequestDto requestDto) {
+        return requestDto.orderLineList()
+                .stream()
+                .map(CreateOrderLineRequestDto::productId)
+                .toList();
+    }
+
+    private void validateProductList(Store store, List<UUID> productIdList) {
+        if (!store.hasProductList(productIdList)) {
+            throw new GlobalException(ResultCase.INVALID_INPUT);
+        }
+    }
+
+    private CreatePaymentRequestDto getCreatePaymentRequestDto(CreateOrderRequestDto requestDto, User user) {
+        PaymentRequestDto paymentInfo = requestDto.paymentInfo();
+        return new CreatePaymentRequestDto(paymentInfo.amount(), paymentInfo.method(), user.getUsername());
+    }
+
+    private void validatePaymentResult(PaymentResponseDto paymentResponse) {
+        if (!paymentResponse.status().equals(PaymentStatus.SUCCESS)) {
+            throw new GlobalException(ResultCase.ORDER_FAILED);
+        }
+    }
+
+    private Order createOrderEntity(CreateOrderRequestDto requestDto, User user, Store store) {
+
+        return Order.create(
+                OrderStatus.ACCEPT_WAITING,
+                requestDto.orderType(),
+                requestDto.comment(),
+                requestDto.address(),
+                user,
+                store
+        );
+    }
+
+    private void addOrderLineListInOrder(CreateOrderRequestDto request, Order order) {
+        request.orderLineList()
+                .stream()
+                .map(orderLineDto -> OrderLine.create(
+                        orderLineDto.quantity(),
+                        new Money(orderLineDto.price()),
+                        null,
+                        order))
+                .forEach(order::addOrderLine);
+    }
+}

--- a/src/main/java/com/nameplz/baedal/domain/payment/dto/response/ExternalPaymentResponseDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/dto/response/ExternalPaymentResponseDto.java
@@ -1,0 +1,7 @@
+package com.nameplz.baedal.domain.payment.dto.response;
+
+public record ExternalPaymentResponseDto(
+        boolean isSuccess,
+        String paymentKey
+) {
+}

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentRequestService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentRequestService.java
@@ -1,0 +1,13 @@
+package com.nameplz.baedal.domain.payment.service;
+
+import com.nameplz.baedal.domain.payment.domain.Payment;
+
+/**
+ * 외부 결제 모듈에 결제 요청하는 도메인 서비스
+ * 도메인 서비스 : 도메인 영역에서 한 애그리거트에 넣기 복잡한 로직을 다루거나, 여러 애그리거트가 필요한 경우 사용
+ * 또는 외부 서비스를 호출하는 로직을 처리할 때 사용 (이때는 인터페이스로 분리하여 구현체를 infra 패키지에 위치)
+ */
+public interface PaymentRequestService {
+
+    void requestPayment(Payment payment);
+}

--- a/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/nameplz/baedal/domain/payment/service/PaymentService.java
@@ -27,6 +27,7 @@ public class PaymentService {
 
     private final PaymentMapper mapper;
     private final PaymentRepository paymentRepository;
+    private final PaymentRequestService paymentRequestService;
 
     /**
      * 결제 조회
@@ -57,9 +58,8 @@ public class PaymentService {
         Payment payment = Payment.create(new Money(request.amount()), request.method(), request.username());
 
         // 외부 결제 모듈에 결제 요청
-        String paymentKey = UUID.randomUUID().toString();
+        paymentRequestService.requestPayment(payment);
 
-        payment.success(paymentKey);
         Payment savedPayment = paymentRepository.save(payment);
 
         return mapper.toPaymentResponseDto(savedPayment);

--- a/src/main/java/com/nameplz/baedal/domain/store/domain/Store.java
+++ b/src/main/java/com/nameplz/baedal/domain/store/domain/Store.java
@@ -4,29 +4,16 @@ import com.nameplz.baedal.domain.category.domain.Category;
 import com.nameplz.baedal.domain.model.BaseEntity;
 import com.nameplz.baedal.domain.territory.domain.Territory;
 import com.nameplz.baedal.domain.user.domain.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "p_store")
@@ -69,8 +56,8 @@ public class Store extends BaseEntity {
     private List<Product> productList = new ArrayList<>();
 
     public static Store createStore(
-        String title, String description, String image, User user, Territory territory,
-        Category category) {
+            String title, String description, String image, User user, Territory territory,
+            Category category) {
         Store store = new Store();
         // 필드 값
         store.title = title;
@@ -98,8 +85,8 @@ public class Store extends BaseEntity {
      * 가게 업데이트
      */
     public void updateStore(String title, String description, String image, StoreStatus status,
-        Territory territory,
-        Category category) {
+                            Territory territory,
+                            Category category) {
         this.title = title;
         this.description = description;
         this.image = image;
@@ -127,5 +114,13 @@ public class Store extends BaseEntity {
      */
     public void updateStoreTerritory(Territory territory) {
         this.territory = territory;
+    }
+
+    /**
+     * 가게의 상품이 존재하는지 확인
+     */
+    public boolean hasProductList(List<UUID> orderedProductIdList) {
+        return productList.stream()
+                .allMatch(product -> orderedProductIdList.contains(product.getId()));
     }
 }

--- a/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
+++ b/src/main/java/com/nameplz/baedal/global/common/response/ResultCase.java
@@ -40,6 +40,8 @@ public enum ResultCase {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, 3002, "주문을 찾을 수 없습니다."),
     // 주문 취소 불가 400
     ORDER_CANCEL_DENIED(HttpStatus.BAD_REQUEST, 3003, "주문을 취소할 수 없습니다."),
+    // 주문 실패 400
+    ORDER_FAILED(HttpStatus.BAD_REQUEST, 3004, "주문에 실패했습니다."),
 
     /* 결제 4000번대 */
 

--- a/src/main/java/com/nameplz/baedal/infra/payment/TossPaymentRequestService.java
+++ b/src/main/java/com/nameplz/baedal/infra/payment/TossPaymentRequestService.java
@@ -1,0 +1,43 @@
+package com.nameplz.baedal.infra.payment;
+
+import com.nameplz.baedal.domain.payment.domain.Payment;
+import com.nameplz.baedal.domain.payment.dto.response.ExternalPaymentResponseDto;
+import com.nameplz.baedal.domain.payment.service.PaymentRequestService;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * 토스 결제 요청 서비스
+ * 실제로 토스 결제 요청 로직을 수행한다고 가정
+ * 외부 서비스 이므로, infra 패키지에 위치
+ * domain 패키지의 PaymentRequestService 도메인 서비스에 의존
+ */
+@Service
+public class TossPaymentRequestService implements PaymentRequestService {
+
+    @Override
+    public void requestPayment(Payment payment) {
+
+        // toss 결제 요청 로직 했다고 가정
+
+        ExternalPaymentResponseDto response = requestExternalPaymentModule(payment);
+
+        if (!response.isSuccess()) {
+            payment.fail();
+        }
+
+        payment.success(response.paymentKey());
+    }
+
+    private ExternalPaymentResponseDto requestExternalPaymentModule(Payment payment) {
+        // 외부 결제 모듈에 결제 요청하는 로직
+        boolean isSuccess = Math.random() >= 0.5;
+
+        if (!isSuccess) {
+            return new ExternalPaymentResponseDto(false, null);
+        }
+
+        return new ExternalPaymentResponseDto(true, UUID.randomUUID().toString());
+    }
+}


### PR DESCRIPTION
## 개요
- 주문 로직을 고도화 했습니다. 

## 작업사항
- 결제 및 주문 서비스를 응용 서비스와 도메인 서비스로 구분 
  - 도메인 서비스는 로직이 복잡하거나 2개 이상의 애그리거트가 필요한 경우 도메인 로직을 별도로 두기 위해 사용합니다. 
  - 응용 서비스는 도메인 객체 간 흐름 제어나 트랜잭션 처리를 담당합니다. 
- 외부 결제 모듈이 있다는 것을 가정하고 결제 도메인 서비스를 구현했습니다.
  - 결제 도메인에 interface를 두고, 외부 결제 모듈은 infra에 interface를 구현하여 DIP를 적용했습니다. 
- 주문 도메인 서비스는 Store, Payment, Order, OrderLine 등의 애그리거트가 섞여있는 복잡한 로직이라 따로 뺐습니다.
- Store 애그리거트에 상품 리스트가 유효한지 검증하는 도메인 로직을 추가했습니다. 
- 인가 처리를 적용했습니다.
  - 기존의 편의 어노테이션을 적용하기 힘든 경우 응용 서비스에서 처리하도록 했습니다. 

## 관련 이슈
- 
