### PR TITLE
feat : redis 권한 캐싱

### DIFF
--- a/src/main/java/com/nameplz/baedal/domain/AiRequest/domain/AiRequest.java
+++ b/src/main/java/com/nameplz/baedal/domain/AiRequest/domain/AiRequest.java
@@ -43,7 +43,7 @@ public class AiRequest extends BaseEntity {
         AiRequest aiRequest = new AiRequest();
 
         // request 데이터가 있고 공백이 아니면 Entity 에 저장
-        if (!requestText.isEmpty() && !requestText.isBlank()) {
+        if (!requestText.isBlank()) {
             aiRequest.requestContent = requestText;
         }
         aiRequest.user = user;

--- a/src/main/java/com/nameplz/baedal/domain/AiRequest/service/AiRequestService.java
+++ b/src/main/java/com/nameplz/baedal/domain/AiRequest/service/AiRequestService.java
@@ -86,6 +86,7 @@ public class AiRequestService {
         String url = apiUrl + "?key=" + apiKey;
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-Type", "application/json");
+        // TODO : httpHeaders.setContentType(MediaType.APPLICATION_JSON); 컨텐츠 타입의 경우 이렇게 따로 setter가 마련되어 있습니다!
 
         HttpEntity<AiRequestDto> requestEntity = new HttpEntity<>(aiRequestDto, headers);
 

--- a/src/main/java/com/nameplz/baedal/domain/user/domain/User.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/domain/User.java
@@ -2,8 +2,15 @@ package com.nameplz.baedal.domain.user.domain;
 
 import com.nameplz.baedal.domain.model.BaseEntity;
 import com.nameplz.baedal.domain.user.dto.request.UserUpdateRequestDto;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -56,15 +63,15 @@ public class User extends BaseEntity {
         this.password = encodedPassword;
     }
 
+    // 회원권한 변경 메서드
+    public void updateRole(UserRole role) {
+        this.role = role;
+    }
+
     // 일반 유저를 가게 주인으로 변경
     public void customerToOwner() {
         if (role.equals(UserRole.CUSTOMER)) {
             role = UserRole.OWNER;
         }
-    }
-
-    // 회원권한 변경 메서드
-    public void updateRole(UserRole role) {
-        this.role = role;
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/user/domain/User.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/domain/User.java
@@ -2,8 +2,15 @@ package com.nameplz.baedal.domain.user.domain;
 
 import com.nameplz.baedal.domain.model.BaseEntity;
 import com.nameplz.baedal.domain.user.dto.request.UserUpdateRequestDto;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -31,6 +38,7 @@ public class User extends BaseEntity {
     @Column(name = "is_public")
     private boolean isPublic;
 
+    // 회원가입 메서드
     public static User create(String username, String password) {
 
         User user = new User();
@@ -42,6 +50,7 @@ public class User extends BaseEntity {
         return user;
     }
 
+    // 회원정보 수정 메서드
     public void update(UserUpdateRequestDto request) {
         this.nickname = request.nickname();
         this.email = request.email();
@@ -53,5 +62,10 @@ public class User extends BaseEntity {
     // 비밀번호 업데이트 메서드
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    // 회원권한 변경 메서드
+    public void updateRole(UserRole role) {
+        this.role = role;
     }
 }

--- a/src/main/java/com/nameplz/baedal/domain/user/domain/UserDto.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/domain/UserDto.java
@@ -1,0 +1,10 @@
+package com.nameplz.baedal.domain.user.domain;
+
+// LocalDateTime 을 제거한 redis 캐싱용 Dto
+public record UserDto(
+    String username,
+    String password,
+    UserRole role
+) {
+
+}

--- a/src/main/java/com/nameplz/baedal/domain/user/service/UserService.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/service/UserService.java
@@ -15,7 +15,6 @@ import com.nameplz.baedal.global.common.security.UserDetailsServiceImpl;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -102,14 +101,13 @@ public class UserService {
     /**
      * 회원정보 전체검색
      */
-    // TODO : java 17에서는 .collect(Collectors.toList()); 부분을 toList();로 줄여서 사용가능합니다!
     // TODO : 컨트롤러 단에서 Pageable 을 받아서 바로 처리할 수 있습니다!
     // import org.springframework.data.domain.Pageable; 입니다!
     public List<UserUpdateResponseDto> getAllUsers(int page, int size, String sortBy) {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(sortBy).descending());
         return userRepository.findAll(pageRequest).stream()
             .map(userMapper::userToUserUpdateResponseDto)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     /**

--- a/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.nameplz.baedal.global.common.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nameplz.baedal.domain.user.domain.UserRole;
 import com.nameplz.baedal.domain.user.dto.request.UserLoginRequestDto;
+import com.nameplz.baedal.global.common.response.CommonResponse;
 import com.nameplz.baedal.global.common.security.UserDetailsImpl;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
@@ -10,9 +11,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -65,9 +68,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         jwtUtil.addJwtToCookie(token, response);
 
         // 로그인 결과 화면 보여주기
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.getWriter().write("{\"message\": \"로그인 성공\", \"token\": \"" + token + "\"}");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        CommonResponse.success("로그인 성공"); // TODO : dto 만들어 토큰까지 담을수도 있음
     }
 
     @Override

--- a/src/main/java/com/nameplz/baedal/global/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/UserDetailsServiceImpl.java
@@ -2,8 +2,10 @@ package com.nameplz.baedal.global.common.security;
 
 import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.domain.user.repository.UserRepository;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -15,15 +17,39 @@ import org.springframework.stereotype.Service;
 public class UserDetailsServiceImpl implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
+    /**
+     * redis 에서 캐싱하여 User 정보를 가져오거나 존재하지 않는다면 RDBMS에서 가져와 redis에 저장
+     */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-        User user = userRepository.findById(username)
+        // redis 에서 해당 유저 조회
+        UserDetailsImpl userDetails = (UserDetailsImpl) redisTemplate.opsForValue().get(username);
+        log.info("인메모리 에서 조회한 user " + userDetails.toString());
+
+        if (userDetails == null) {
+            // redis 에 없다면 DB에서 조회
+            User user = userRepository.findById(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
-        log.info("조회한 user " +user.toString());
+            log.info("RDBMS 에서 조회한 user " + user.toString());
 
-        return new UserDetailsImpl(user);
+            // UserDetailsImpl 객체 생성
+            userDetails = new UserDetailsImpl(user);
+
+            // Redis에 캐싱, 만료 시간 1시간 설정
+            redisTemplate.opsForValue().set(username, userDetails, 1, TimeUnit.HOURS);
+        }
+
+        return userDetails;
+    }
+
+    /**
+     * 권한 업데이트시 캐시 삭제 (UserDetailService 에서 처리하여 캐시 관리 책임을 집중화시킴)
+     */
+    public void removeUserFromCache(String username) {
+        redisTemplate.delete(username);
     }
 }

--- a/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
@@ -37,6 +37,7 @@ public class RedisConfig {
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 
+        // Redis 연결 설정
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         // Serializer 설정

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,9 +6,9 @@ spring:
     password: 1234
   data:
     redis:
-      host: localhost
+      host: 172.17.129.27 # 도커 IP
       port: 6379
-      username: default
+      #      username: default
       password:
   jpa:
     hibernate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,9 +6,9 @@ spring:
     password: 1234
   data:
     redis:
-      host: 172.17.129.27 # 도커 IP
+      host: localhost
       port: 6379
-      #      username: default
+      username: default
       password:
   jpa:
     hibernate:


### PR DESCRIPTION
## 개요
- 권한  캐싱하기

## 작업사항
- userDetailsServiceImpl 에서 유저 정보를 가져올 때 캐싱된 데이터를 우선적으로 가져오고 없다면 DB조회후 캐싱해놓았습니다
- userDetailsServiceImpl 에서 레디스 캐시데이터 삭제함수를 만들고 UserService 에서 권한 업데이트를 할 때 이 함수를 불러서 권한 변경이 있을때 삭제하도록 했습니다.

![image](https://github.com/user-attachments/assets/046ea5cc-6e58-4e78-a8f7-dddf6986d39f)


## 관련 이슈
- window WSL 도커 위에서 작업하다보니 localhost 가 아니라 도커 IP(?) 를 redis 주소로 사용해야되는 이슈가 있었음 (다시 돌려놓음)
- 레디스 캐싱시 User Entity 의 생성일자인 LocalDateTime 이 redis 로 직렬화/역직렬화 될 때 문제가 있었고 이는 LocalDateTime 이 사용되는 필드는 제거한 UserDTO 를 만들어 이것을 캐싱하는식으로 해결하였습니다