### PR TITLE
User을 DB보다 Redis에서 먼저 호출해서 처리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
     permissions:
       contents: read
       # 아래는 /publish-unit-test-result-action 의 권한 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // redis에서 LocalDateTime 변환용
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/nameplz/baedal/domain/user/controller/UserController.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/controller/UserController.java
@@ -17,7 +17,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -52,7 +54,14 @@ public class UserController {
     // TODO :로그아웃 (Spring Security에서 기본적으로 Stateless 설정으로 인해 로그아웃 기능은 필요하지 않지만, 추가적으로 구현할 수 있다?)
     // TODO : JWT 특성상 서버에서 제어권이 없기 때문에 로그아웃을 구현할 수 없지만, 서버에 로그아웃된 JWT를 블랙리스트로 저장해두고 이후 동일한 토큰으로 요청 시 로그인이 필요하다고 응답하는 식으로 구현하면 됩니다. 로그인 시에는 블랙리스트가 있는지 확인 후 있으면 삭제해주는 식으로요!
     @PostMapping("/logout")
-    public CommonResponse<EmptyResponseDto> logout(HttpServletResponse response) {
+    public CommonResponse<EmptyResponseDto> logout(
+        @AuthenticationPrincipal UserDetails userDetails,
+        HttpServletResponse response) {
+
+        // 캐시를 지우는 함수
+        userService.logout(userDetails.getUsername());
+
+        // 쿠키 삭제
         Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, null);
         cookie.setMaxAge(0);
         cookie.setPath("/");

--- a/src/main/java/com/nameplz/baedal/domain/user/controller/UserController.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/controller/UserController.java
@@ -59,7 +59,9 @@ public class UserController {
         HttpServletResponse response) {
 
         // 캐시를 지우는 함수
-        userService.logout(userDetails.getUsername());
+        if (userDetails != null) {
+            userService.logout(userDetails.getUsername());
+        }
 
         // 쿠키 삭제
         Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, null);

--- a/src/main/java/com/nameplz/baedal/domain/user/domain/User.java
+++ b/src/main/java/com/nameplz/baedal/domain/user/domain/User.java
@@ -53,6 +53,17 @@ public class User extends BaseEntity {
         return user;
     }
 
+    /**
+     * Redis용 User 생성 => 별도 Principal을 생성하는 것이 좋아보임
+     */
+    public static User createForPrincipal(String username, UserRole role) {
+        User user = new User();
+        user.username = username;
+        user.role = role;
+
+        return user;
+    }
+
     public void update(UserUpdateRequestDto request) {
         this.nickname = request.nickname();
         this.email = request.email();

--- a/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.nameplz.baedal.global.common.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nameplz.baedal.domain.user.domain.UserRole;
 import com.nameplz.baedal.domain.user.dto.request.UserLoginRequestDto;
+import com.nameplz.baedal.global.common.redis.RedisUtils;
 import com.nameplz.baedal.global.common.security.UserDetailsImpl;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
@@ -23,6 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final JwtUtil jwtUtil;
+    private final RedisUtils redisUtils;
 
     @PostConstruct
     void setup() {
@@ -60,6 +62,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         log.info("로그인 성공 및 JWT 생성");
         String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
         UserRole role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        // 인증에 성공하였으면 redis에 저장
+        redisUtils.setUserData(username, role);
 
         String token = jwtUtil.createToken(username, role);
         jwtUtil.addJwtToCookie(token, response);

--- a/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthorizationFilter.java
@@ -90,6 +90,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         // User 정보가 없으면 DB에서 갖고 온다.
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        // 인증에 성공하였으면 redis에 저장
+        redisUtils.setUserData(username, ((UserDetailsImpl) userDetails).getUser().getRole());
         return new UsernamePasswordAuthenticationToken(userDetails, null,
             userDetails.getAuthorities());
     }

--- a/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/nameplz/baedal/global/common/jwt/JwtAuthorizationFilter.java
@@ -1,5 +1,10 @@
 package com.nameplz.baedal.global.common.jwt;
 
+import com.nameplz.baedal.domain.user.domain.User;
+import com.nameplz.baedal.domain.user.domain.UserRole;
+import com.nameplz.baedal.global.common.redis.RedisUtils;
+import com.nameplz.baedal.global.common.redis.dto.UserAuthDto;
+import com.nameplz.baedal.global.common.security.UserDetailsImpl;
 import com.nameplz.baedal.global.common.security.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -17,14 +22,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
 @Slf4j(topic = "JwtAuthorizationFilter - JWT 검증 및 인가")
 @RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private final RedisUtils redisUtils;
 
     // 로그인을 제외한 요청마다 필터실행. jwt에 담긴 정보를 추출해 authentication 객체에 저장
     @Override
@@ -51,7 +55,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
 
             try {
-                setAuthentication(info.getSubject());
+                setAuthentication(info.getSubject(),
+                    UserRole.valueOf((String) info.get(JwtUtil.AUTHORIZATION_KEY)));
             } catch (Exception e) {
                 log.error(e.getMessage());
                 return;
@@ -59,19 +64,31 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(req, res);
+
     }
 
     // 인증 처리
-    public void setAuthentication(String username) {
+    public void setAuthentication(String username, UserRole role) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        Authentication authentication = createAuthentication(username);
+        Authentication authentication = createAuthentication(username, role);
         context.setAuthentication(authentication);
 
         SecurityContextHolder.setContext(context);
     }
 
     // 인증 객체 생성
-    private Authentication createAuthentication(String username) {
+    private Authentication createAuthentication(String username, UserRole role) {
+        //Redis에 User 정보가 있는지 확인한다.
+        UserAuthDto userAuthDto = redisUtils.findUserData(username);
+        if (userAuthDto != null) {
+            // 여기서 UserDetailsPrincipal 생성할 때 객체를 User 말고 다른 걸 사용하는 게 좋아보입니다.
+            UserDetailsImpl userDetails = new UserDetailsImpl(
+                User.createForPrincipal(username, role));
+            return new UsernamePasswordAuthenticationToken(userDetails, null,
+                userDetails.getAuthorities());
+        }
+
+        // User 정보가 없으면 DB에서 갖고 온다.
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         return new UsernamePasswordAuthenticationToken(userDetails, null,
             userDetails.getAuthorities());

--- a/src/main/java/com/nameplz/baedal/global/common/redis/RedisProperty.java
+++ b/src/main/java/com/nameplz/baedal/global/common/redis/RedisProperty.java
@@ -1,0 +1,12 @@
+package com.nameplz.baedal.global.common.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.data.redis")
+public record RedisProperty(
+    String host,
+    int port,
+    String password
+) {
+
+}

--- a/src/main/java/com/nameplz/baedal/global/common/redis/RedisUtils.java
+++ b/src/main/java/com/nameplz/baedal/global/common/redis/RedisUtils.java
@@ -1,0 +1,42 @@
+package com.nameplz.baedal.global.common.redis;
+
+import com.nameplz.baedal.domain.user.domain.UserRole;
+import com.nameplz.baedal.global.common.redis.dto.UserAuthDto;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtils {
+
+
+    private static final Long expiredTime = 1000 * 60 * 60L;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * Redis에 유저 정보 저장
+     */
+    public void setUserData(String username, UserRole role) {
+        UserAuthDto userAuthDto = UserAuthDto.of(username, role, LocalDateTime.now());
+
+        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ops.set(username, userAuthDto, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    /***
+     *
+     */
+    public UserAuthDto findUserData(String username) {
+        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        return (UserAuthDto) ops.get(username);
+    }
+
+    public void deleteUserData(String username) {
+        redisTemplate.delete(username);
+    }
+
+}

--- a/src/main/java/com/nameplz/baedal/global/common/redis/RedisUtils.java
+++ b/src/main/java/com/nameplz/baedal/global/common/redis/RedisUtils.java
@@ -15,7 +15,7 @@ public class RedisUtils {
 
 
     private static final Long expiredTime = 1000 * 60 * 60L;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, UserAuthDto> redisTemplate;
 
     /**
      * Redis에 유저 정보 저장
@@ -23,7 +23,7 @@ public class RedisUtils {
     public void setUserData(String username, UserRole role) {
         UserAuthDto userAuthDto = UserAuthDto.of(username, role, LocalDateTime.now());
 
-        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ValueOperations<String, UserAuthDto> ops = redisTemplate.opsForValue();
         ops.set(username, userAuthDto, expiredTime, TimeUnit.MILLISECONDS);
     }
 
@@ -31,8 +31,8 @@ public class RedisUtils {
      *
      */
     public UserAuthDto findUserData(String username) {
-        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
-        return (UserAuthDto) ops.get(username);
+        ValueOperations<String, UserAuthDto> ops = redisTemplate.opsForValue();
+        return ops.get(username);
     }
 
     public void deleteUserData(String username) {

--- a/src/main/java/com/nameplz/baedal/global/common/redis/dto/UserAuthDto.java
+++ b/src/main/java/com/nameplz/baedal/global/common/redis/dto/UserAuthDto.java
@@ -1,0 +1,25 @@
+package com.nameplz.baedal.global.common.redis.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.nameplz.baedal.domain.user.domain.UserRole;
+import java.time.LocalDateTime;
+
+public record UserAuthDto(String username, UserRole role,
+                          @JsonSerialize(using = LocalDateTimeSerializer.class)
+                          @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                          @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+                          LocalDateTime createTime) {
+
+    public static UserAuthDto of(String username, UserRole role,
+        LocalDateTime createTime) {
+
+        return new UserAuthDto(username, role, createTime);
+
+    }
+
+}

--- a/src/main/java/com/nameplz/baedal/global/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/UserDetailsServiceImpl.java
@@ -2,6 +2,7 @@ package com.nameplz.baedal.global.common.security;
 
 import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.domain.user.repository.UserRepository;
+import com.nameplz.baedal.global.common.redis.RedisUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,15 +16,18 @@ import org.springframework.stereotype.Service;
 public class UserDetailsServiceImpl implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final RedisUtils redisUtils;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
         User user = userRepository.findById(username)
-                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+            .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
-        log.info("조회한 user " +user.toString());
+        log.info("조회한 user " + user.toString());
 
+        // 인증에 성공하였으면 redis에 저장
+        redisUtils.setUserData(username, user.getRole());
         return new UserDetailsImpl(user);
     }
 }

--- a/src/main/java/com/nameplz/baedal/global/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/nameplz/baedal/global/common/security/UserDetailsServiceImpl.java
@@ -2,7 +2,6 @@ package com.nameplz.baedal.global.common.security;
 
 import com.nameplz.baedal.domain.user.domain.User;
 import com.nameplz.baedal.domain.user.repository.UserRepository;
-import com.nameplz.baedal.global.common.redis.RedisUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class UserDetailsServiceImpl implements UserDetailsService {
 
     private final UserRepository userRepository;
-    private final RedisUtils redisUtils;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -25,9 +23,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
             .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
         log.info("조회한 user " + user.toString());
-
-        // 인증에 성공하였으면 redis에 저장
-        redisUtils.setUserData(username, user.getRole());
         return new UserDetailsImpl(user);
     }
 }

--- a/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
@@ -24,9 +24,6 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
 
-        // log.info("호스트 : {}, 포트 : {}, 비밀번호 : {}", redisProperty.host(), redisProperty.port(),
-        //     redisProperty.password());
-
         config.setHostName(redisProperty.host());
         config.setPort(redisProperty.port());
         config.setPassword(redisProperty.password());

--- a/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
@@ -1,6 +1,7 @@
 package com.nameplz.baedal.global.config;
 
 import com.nameplz.baedal.global.common.redis.RedisProperty;
+import com.nameplz.baedal.global.common.redis.dto.UserAuthDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +35,26 @@ public class RedisConfig {
     @Bean
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Serializer 설정
+        redisTemplate.setKeySerializer(RedisSerializer.string());
+        redisTemplate.setValueSerializer(RedisSerializer.json());
+
+        // Hash Serializer 설정
+        redisTemplate.setHashKeySerializer(RedisSerializer.string());
+        redisTemplate.setHashValueSerializer(RedisSerializer.json());
+
+        return redisTemplate;
+    }
+
+    /**
+     * UserAuth용 Redis Template
+     */
+    @Bean
+    public RedisTemplate<String, UserAuthDto> userAuthDtoRedisTemplate() {
+        RedisTemplate<String, UserAuthDto> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 

--- a/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
+++ b/src/main/java/com/nameplz/baedal/global/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.nameplz.baedal.global.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.nameplz.baedal.global.common.redis.RedisProperty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -10,25 +12,24 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
+@Slf4j
+@RequiredArgsConstructor
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
 
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.password}")
-    private String password;
+    private final RedisProperty redisProperty;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
 
-        config.setHostName(host);
-        config.setPort(port);
-        config.setPassword(password);
+        // log.info("호스트 : {}, 포트 : {}, 비밀번호 : {}", redisProperty.host(), redisProperty.port(),
+        //     redisProperty.password());
+
+        config.setHostName(redisProperty.host());
+        config.setPort(redisProperty.port());
+        config.setPassword(redisProperty.password());
 
         return new LettuceConnectionFactory(config);
     }

--- a/src/test/java/com/nameplz/baedal/global/common/redis/RedisUtilsTest.java
+++ b/src/test/java/com/nameplz/baedal/global/common/redis/RedisUtilsTest.java
@@ -15,7 +15,10 @@ import org.springframework.data.redis.core.ValueOperations;
 class RedisUtilsTest {
 
     @Autowired
-    private RedisTemplate<String, Object> redisTemplate;
+    private RedisTemplate<String, UserAuthDto> redisTemplate;
+
+    @Autowired
+    private RedisTemplate<String, Object> objectRedisTemplate;
 
     @Test
     void 레디스_저장_읽기_테스트() {
@@ -26,9 +29,9 @@ class RedisUtilsTest {
         UserAuthDto userAuthDto = UserAuthDto.of(username, role, LocalDateTime.now());
 
         // when
-        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ValueOperations<String, UserAuthDto> ops = redisTemplate.opsForValue();
         ops.set(username, userAuthDto, 1000 * 60, TimeUnit.MILLISECONDS);
-        UserAuthDto output = (UserAuthDto) ops.get(username);
+        UserAuthDto output = ops.get(username);
 
         // then
         Assertions.assertThat(output.username()).isEqualTo(username);
@@ -42,7 +45,7 @@ class RedisUtilsTest {
         String username = "yahoo";
         UserRole role = UserRole.MASTER;
         UserAuthDto userAuthDto = UserAuthDto.of(username, role, LocalDateTime.now());
-        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ValueOperations<String, Object> ops = objectRedisTemplate.opsForValue();
         ops.set(username, userAuthDto, 1000 * 60 * 60, TimeUnit.MILLISECONDS);
 
         // when

--- a/src/test/java/com/nameplz/baedal/global/common/redis/RedisUtilsTest.java
+++ b/src/test/java/com/nameplz/baedal/global/common/redis/RedisUtilsTest.java
@@ -1,0 +1,56 @@
+package com.nameplz.baedal.global.common.redis;
+
+import com.nameplz.baedal.domain.user.domain.UserRole;
+import com.nameplz.baedal.global.common.redis.dto.UserAuthDto;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+class RedisUtilsTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    void 레디스_저장_읽기_테스트() {
+
+        // given
+        String username = "yahoo";
+        UserRole role = UserRole.MASTER;
+        UserAuthDto userAuthDto = UserAuthDto.of(username, role, LocalDateTime.now());
+
+        // when
+        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ops.set(username, userAuthDto, 1000 * 60, TimeUnit.MILLISECONDS);
+        UserAuthDto output = (UserAuthDto) ops.get(username);
+
+        // then
+        Assertions.assertThat(output.username()).isEqualTo(username);
+        Assertions.assertThat(output.role()).isEqualTo(UserRole.MASTER);
+
+    }
+
+    @Test
+    void 레디스_삭제_테스트() {
+
+        String username = "yahoo";
+        UserRole role = UserRole.MASTER;
+        UserAuthDto userAuthDto = UserAuthDto.of(username, role, LocalDateTime.now());
+        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ops.set(username, userAuthDto, 1000 * 60 * 60, TimeUnit.MILLISECONDS);
+
+        // when
+        redisTemplate.delete(username);
+
+        // then
+        UserAuthDto output = (UserAuthDto) ops.get(username);
+        Assertions.assertThat(output).isNull();
+    }
+
+}


### PR DESCRIPTION
## 개요
- 인증에서 User 정보 갖고 올 때 Redis를 먼저 활용

## 작업사항
- 유저 인증 정보 저장할 때 유저 정보를 Redis에서 먼저 갖고 옴
- 유저 관련 변경 및 로그아웃을 할 때 Redis 캐시 삭제
- RedisConfig 별도로 분리
- 테스트를 위한 ci 환경에 redis 추가
